### PR TITLE
fix(ci): quote DATABASE_URL to prevent YAML parse error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Run tests
         run: pytest tests/ -v --tb=short
         env:
-          DATABASE_URL: sqlite+aiosqlite:///:memory:
+          DATABASE_URL: "sqlite+aiosqlite:///:memory:"
           SECRET_KEY: ci-test-secret-key
           ENVIRONMENT: development


### PR DESCRIPTION
## Summary
- The `DATABASE_URL` value `sqlite+aiosqlite:///:memory:` ends with a colon, which YAML interprets as a block mapping key indicator
- This caused the workflow to fail immediately with "workflow file issue" (0 jobs)
- Fix: wrap the value in double quotes

## Test plan
- [ ] CI workflow parses correctly and jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)