### PR TITLE
Accept operator_password on auth register

### DIFF
--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,12 +1,20 @@
 from datetime import datetime
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, model_validator
 
 
 class UserCreate(BaseModel):
     email: EmailStr
     password: str
     full_name: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def populate_password_from_operator_password(cls, data):
+        if isinstance(data, dict) and "password" not in data and "operator_password" in data:
+            data = data.copy()
+            data["password"] = data["operator_password"]
+        return data
 
 
 class UserRead(BaseModel):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,6 +15,18 @@ async def test_register(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_register_accepts_operator_password(client: AsyncClient):
+    resp = await client.post(
+        "/auth/register",
+        json={"email": "alias@example.com", "operator_password": "pass1234", "full_name": "Alias"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["email"] == "alias@example.com"
+    assert "id" in data
+
+
+@pytest.mark.asyncio
 async def test_register_duplicate(client: AsyncClient):
     payload = {"email": "dup@example.com", "password": "pass1234", "full_name": "Dup"}
     await client.post("/auth/register", json=payload)


### PR DESCRIPTION
## Summary
- accept `operator_password` as an alias for `password` on `/auth/register`
- keep `password` as the canonical field so existing clients keep working
- add a regression test for registration via `operator_password`