### PR TITLE
Remove password requirement from public agent registration

### DIFF
--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
 
 from app.core.aicid_id import generate_aicid
-from app.core.security import hash_password, verify_password
 from app.database import get_db
 from app.models.agent import Agent
 from app.models.user import User
@@ -135,7 +134,6 @@ async def register_submit(
     agent_name: str = Form(...),
     human_operator: str = Form(...),
     operator_email: str = Form(...),
-    operator_password: str = Form(...),
     base_model: Optional[str] = Form(None),
     version: Optional[str] = Form(None),
     agent_harness: Optional[str] = Form(None),
@@ -149,7 +147,7 @@ async def register_submit(
         "agent_harness": agent_harness or "",
     }
 
-    # Get or create user
+    # Group public registrations by operator email without requiring account auth.
     result = await db.execute(select(User).where(User.email == operator_email))
     user = result.scalar_one_or_none()
 
@@ -157,16 +155,10 @@ async def register_submit(
         user = User(
             email=operator_email,
             full_name=human_operator,
-            hashed_password=hash_password(operator_password),
+            hashed_password=None,
         )
         db.add(user)
         await db.flush()
-    elif not user.hashed_password or not verify_password(operator_password, user.hashed_password):
-        return templates.TemplateResponse(
-            "register.html",
-            {"request": request, "error": "Registration failed. Please check your credentials.", "values": values},
-            status_code=400,
-        )
 
     aicid = await _unique_aicid(db)
     agent = Agent(

--- a/templates/register.html
+++ b/templates/register.html
@@ -92,7 +92,7 @@
             placeholder="you@example.com"
             value="{{ values.operator_email or '' }}"
           >
-          <span class="form-hint">Used to create or identify your account.</span>
+          <span class="form-hint">Used to group your agent registrations under one operator.</span>
         </div>
       </fieldset>
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -19,7 +19,6 @@ async def test_register_form_post_creates_agent(client: AsyncClient):
             "agent_name": "TestBot",
             "human_operator": "Alice",
             "operator_email": "alice@example.com",
-            "operator_password": "pass1234",
         },
         follow_redirects=False,
     )
@@ -32,26 +31,24 @@ async def test_register_form_post_creates_agent(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_register_form_post_wrong_password(client: AsyncClient):
-    # First registration creates the account
+    # First registration creates the operator record.
     await client.post(
         "/register",
         data={
             "agent_name": "Bot1",
             "human_operator": "Alice",
             "operator_email": "alice@example.com",
-            "operator_password": "correct",
         },
         follow_redirects=False,
     )
-    # Second registration with wrong password returns 400
+    # A later registration with the same email should still succeed without credentials.
     resp = await client.post(
         "/register",
         data={
             "agent_name": "Bot2",
             "human_operator": "Alice",
             "operator_email": "alice@example.com",
-            "operator_password": "wrong",
         },
         follow_redirects=False,
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 303


### PR DESCRIPTION
## Summary
- remove the stale password requirement from the public `/register` handler
- keep public registrations grouped by operator email without credential checks
- update the form copy and tests to reflect the password-free flow