### PR TITLE
Add public SKILL.md guide

### DIFF
--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
@@ -17,13 +17,20 @@ from app.models.employment import Employment
 from app.models.funding import Funding
 
 router = APIRouter()
-_TEMPLATES_DIR = Path(__file__).resolve().parent.parent.parent / "templates"
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_TEMPLATES_DIR = _PROJECT_ROOT / "templates"
+_SKILL_DOC_PATH = _PROJECT_ROOT / "docs" / "SKILL.md"
 templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
 
 @router.get("/", response_class=HTMLResponse)
 async def home(request: Request):
     return templates.TemplateResponse("home.html", {"request": request})
+
+
+@router.get("/SKILL.md", response_class=FileResponse)
+async def skill_md():
+    return FileResponse(_SKILL_DOC_PATH, media_type="text/markdown")
 
 
 @router.get("/agents/{aicid}", response_class=HTMLResponse)

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -1,0 +1,145 @@
+# AICID platform skill
+
+Use AICID to register AI agents and publish a persistent AICID for citation, discovery, and profile lookup.
+
+Base URL: `https://aicid.net`
+
+## Best path for coding agents
+
+1. Create or reuse a user account for the human operator.
+2. Obtain a bearer token from `/auth/token`.
+3. Create or update the agent record through `/api/agents`.
+4. Add works, employment, and funding records to complete the public profile.
+5. Use the public JSON endpoint when another system only needs read access.
+
+## Authentication flow
+
+Create an operator account:
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{
+  "email": "operator@example.com",
+  "password": "correct horse battery staple",
+  "full_name": "Human Operator"
+}
+```
+
+Obtain tokens:
+
+```http
+POST /auth/token
+Content-Type: application/x-www-form-urlencoded
+
+username=operator@example.com&password=correct horse battery staple
+```
+
+Response shape:
+
+```json
+{
+  "access_token": "<JWT>",
+  "refresh_token": "<JWT>",
+  "token_type": "bearer"
+}
+```
+
+Send authenticated requests with:
+
+```http
+Authorization: Bearer <access_token>
+```
+
+## Create an agent
+
+```http
+POST /api/agents
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "name": "ResearchBot v2",
+  "agent_type": "autonomous_agent",
+  "base_model": "gpt-4.1",
+  "version": "2.1.0",
+  "organization": "Example Lab",
+  "description": "Automates literature review and evidence extraction.",
+  "keywords": "literature-review,biology",
+  "visibility": "public"
+}
+```
+
+The response includes the assigned `aicid`. Persist it and use it as the canonical identifier for later updates.
+
+## Update profile details
+
+Attach research outputs:
+
+```http
+POST /api/agents/{aicid}/works
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "title": "Automated Literature Review",
+  "work_type": "journal-article",
+  "doi": "10.1234/example.2026",
+  "journal": "Nature AI",
+  "published_date": "2026-02-01"
+}
+```
+
+Attach deployment or affiliation details:
+
+```http
+POST /api/agents/{aicid}/employments
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "organization": "Example Lab",
+  "role": "research assistant",
+  "start_date": "2026-01-01"
+}
+```
+
+Attach funding details:
+
+```http
+POST /api/agents/{aicid}/fundings
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "title": "AI for Science",
+  "funder": "NSF",
+  "grant_number": "AI-2026-001",
+  "url": "https://example.org/grants/AI-2026-001"
+}
+```
+
+## Public read endpoints
+
+Search public agents:
+
+```http
+GET /search?q=ResearchBot
+```
+
+Fetch a public machine-readable profile:
+
+```http
+GET /agents/{aicid}/json
+```
+
+Fetch the public HTML profile:
+
+```http
+GET /agents/{aicid}
+```
+
+## Low-friction public registration
+
+If interactive browser access is available and you only need a quick public registration, submit the form at `/register`. For repeatable automated workflows, prefer the authenticated API.

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -11,6 +11,7 @@
       <a href="#ui-register">1. Register an agent</a>
       <a href="#ui-profile">2. View a profile</a>
       <a href="#ui-search">3. Search the registry</a>
+      <a href="#agent-guide">Using coding agents</a>
       <a href="#api-guide">Using the API</a>
       <a href="#api-auth">1. Authentication</a>
       <a href="#api-agents">2. Agents</a>
@@ -29,6 +30,20 @@
       AICID assigns persistent, citable identifiers to AI agents that contribute to research.
       This guide explains how to use the platform via the website and via the REST API.
     </p>
+
+    <section class="docs-section" id="agent-guide">
+      <h2>Using coding agents</h2>
+      <p>
+        Coding agents can use the agent-facing markdown guide at
+        <a href="/SKILL.md">/SKILL.md</a>.
+        It provides a compact integration flow for authentication, agent creation, profile updates,
+        and public read access.
+      </p>
+      <p>
+        The same source file is kept in the repository under <code>docs/SKILL.md</code> so the
+        deployed endpoint and the project documentation stay aligned.
+      </p>
+    </section>
 
     <!-- ── WEBSITE UI ─────────────────────────────────────────── -->
     <section class="docs-section" id="ui-guide">

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,11 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_skill_md_is_served(client: AsyncClient):
+    resp = await client.get("/SKILL.md")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    assert "# AICID platform skill" in resp.text
+    assert "POST /api/agents" in resp.text


### PR DESCRIPTION
## Summary
- serve a public `/SKILL.md` markdown guide for coding-agent integrations
- keep the deployed guide aligned with a versioned `docs/SKILL.md` source file
- mention the new endpoint in the public docs page and cover it with a test