### PR TITLE
Show operator name badge on agent profile page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -216,6 +216,7 @@ main { flex: 1; }
   font-weight: 600;
 }
 .badge-type { background: #e0f0ff; color: #1a5fa8; }
+.badge-operator { background: #f0e8ff; color: #5a1a8a; }
 .badge-limited { background: #fff0cc; color: #8a5c00; }
 .badge-work-type { background: #e8f4c0; color: #3a5215; margin-right: 0.4rem; }
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -9,6 +9,9 @@
     <div class="aicid-badge-large">{{ agent.aicid }}</div>
     <div class="agent-meta">
       <span class="badge badge-type">{{ agent.agent_type.replace("_", " ").title() }}</span>
+      {% if agent.human_operator %}
+        <span class="badge badge-operator">{{ agent.human_operator }}</span>
+      {% endif %}
       {% if agent.visibility == "limited" %}
         <span class="badge badge-limited">Limited</span>
       {% endif %}

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -104,3 +104,24 @@ async def test_public_profile_json(client: AsyncClient, auth_headers: dict):
     resp = await client.get(f"/agents/{aicid}/json")
     assert resp.status_code == 200
     assert resp.json()["aicid"] == aicid
+
+
+@pytest.mark.asyncio
+async def test_public_profile_shows_agent_type_and_operator(client: AsyncClient, auth_headers: dict):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "CopilotBot",
+            "agent_type": "co_scientist",
+            "human_operator": "Martin Monperrus",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert 'class="badge badge-type"' in resp.text
+    assert 'class="badge badge-operator"' in resp.text
+    assert "Co Scientist" in resp.text
+    assert "Martin Monperrus" in resp.text


### PR DESCRIPTION
## Summary
- Display `human_operator` as a `badge-operator` badge in the agent profile sidebar, alongside the existing agent type badge
- Add `.badge-operator` CSS class (purple/lavender `#f0e8ff`) so the two badges are visually distinct but the same size
- Add test `test_public_profile_shows_agent_type_and_operator` verifying both badges appear in the profile HTML

## Test plan
- [ ] `pytest tests/test_agents.py::test_public_profile_shows_agent_type_and_operator` passes
- [ ] Visit an agent profile with a `human_operator` set and confirm both badges render side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)