### PR TITLE
Require human_operator on agent creation

### DIFF
--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -154,6 +154,13 @@ async def register_submit(
         "agent_harness": agent_harness or "",
     }
 
+    if not human_operator or not human_operator.strip():
+        return templates.TemplateResponse(
+            "register.html",
+            {"request": request, "error": "Operator name is required.", "values": values},
+            status_code=422,
+        )
+
     # Group public registrations by operator email without requiring account auth.
     result = await db.execute(select(User).where(User.email == operator_email))
     user = result.scalar_one_or_none()
@@ -172,7 +179,7 @@ async def register_submit(
         owner_id=user.id,
         aicid=aicid,
         name=agent_name,
-        human_operator=human_operator or None,
+        human_operator=human_operator.strip(),
         agent_harness=agent_harness or None,
         base_model=base_model or None,
         version=version or None,

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,12 +1,19 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class AgentCreate(BaseModel):
     name: str
-    human_operator: Optional[str] = None
+    human_operator: str
+
+    @field_validator("human_operator")
+    @classmethod
+    def human_operator_nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("human_operator is required")
+        return v
     agent_harness: Optional[str] = None
     agent_type: str = "autonomous_agent"
     base_model: Optional[str] = None

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -64,6 +64,7 @@ Content-Type: application/json
 
 {
   "name": "ResearchBot v2",
+  "human_operator": "Jane Smith",
   "agent_type": "autonomous_agent",
   "base_model": "gpt-4.1",
   "version": "2.1.0",
@@ -73,6 +74,8 @@ Content-Type: application/json
   "visibility": "public"
 }
 ```
+
+`human_operator` (the full name of the person responsible for the agent) is **required**. The request is rejected with HTTP 422 if it is missing or blank.
 
 The response includes the assigned `aicid`. Persist it and use it as the canonical identifier for later updates.
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -25,7 +25,7 @@ def test_aicid_invalid():
 async def test_create_agent(client: AsyncClient, auth_headers: dict):
     resp = await client.post(
         "/api/agents",
-        json={"name": "ResearchBot", "agent_type": "autonomous_agent", "base_model": "GPT-4"},
+        json={"name": "ResearchBot", "human_operator": "Alice", "agent_type": "autonomous_agent", "base_model": "GPT-4"},
         headers=auth_headers,
     )
     assert resp.status_code == 201
@@ -35,15 +35,35 @@ async def test_create_agent(client: AsyncClient, auth_headers: dict):
 
 
 @pytest.mark.asyncio
+async def test_create_agent_without_operator_rejected(client: AsyncClient, auth_headers: dict):
+    resp = await client.post(
+        "/api/agents",
+        json={"name": "NoOperatorBot"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_agent_empty_operator_rejected(client: AsyncClient, auth_headers: dict):
+    resp = await client.post(
+        "/api/agents",
+        json={"name": "EmptyOperatorBot", "human_operator": "  "},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_list_agents(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/agents",
-        json={"name": "Bot1"},
+        json={"name": "Bot1", "human_operator": "Alice"},
         headers=auth_headers,
     )
     await client.post(
         "/api/agents",
-        json={"name": "Bot2"},
+        json={"name": "Bot2", "human_operator": "Alice"},
         headers=auth_headers,
     )
     resp = await client.get("/api/agents", headers=auth_headers)
@@ -55,7 +75,7 @@ async def test_list_agents(client: AsyncClient, auth_headers: dict):
 async def test_update_agent(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",
-        json={"name": "OldName"},
+        json={"name": "OldName", "human_operator": "Alice"},
         headers=auth_headers,
     )
     aicid = create_resp.json()["aicid"]
@@ -72,7 +92,7 @@ async def test_update_agent(client: AsyncClient, auth_headers: dict):
 async def test_delete_agent(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",
-        json={"name": "ToDelete"},
+        json={"name": "ToDelete", "human_operator": "Alice"},
         headers=auth_headers,
     )
     aicid = create_resp.json()["aicid"]
@@ -84,7 +104,7 @@ async def test_delete_agent(client: AsyncClient, auth_headers: dict):
 async def test_search_agents(client: AsyncClient, auth_headers: dict):
     await client.post(
         "/api/agents",
-        json={"name": "ScienceBot", "keywords": "biology,chemistry", "visibility": "public"},
+        json={"name": "ScienceBot", "human_operator": "Alice", "keywords": "biology,chemistry", "visibility": "public"},
         headers=auth_headers,
     )
     resp = await client.get("/search?q=ScienceBot")
@@ -97,7 +117,7 @@ async def test_search_agents(client: AsyncClient, auth_headers: dict):
 async def test_public_profile_json(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",
-        json={"name": "PublicBot", "visibility": "public"},
+        json={"name": "PublicBot", "human_operator": "Alice", "visibility": "public"},
         headers=auth_headers,
     )
     aicid = create_resp.json()["aicid"]

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient
 async def test_add_and_list_work(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",
-        json={"name": "WorkBot"},
+        json={"name": "WorkBot", "human_operator": "Alice"},
         headers=auth_headers,
     )
     aicid = create_resp.json()["aicid"]
@@ -28,7 +28,7 @@ async def test_add_and_list_work(client: AsyncClient, auth_headers: dict):
 
 @pytest.mark.asyncio
 async def test_update_work(client: AsyncClient, auth_headers: dict):
-    create_resp = await client.post("/api/agents", json={"name": "Bot"}, headers=auth_headers)
+    create_resp = await client.post("/api/agents", json={"name": "Bot", "human_operator": "Alice"}, headers=auth_headers)
     aicid = create_resp.json()["aicid"]
 
     work_resp = await client.post(
@@ -49,7 +49,7 @@ async def test_update_work(client: AsyncClient, auth_headers: dict):
 
 @pytest.mark.asyncio
 async def test_delete_work(client: AsyncClient, auth_headers: dict):
-    create_resp = await client.post("/api/agents", json={"name": "Bot"}, headers=auth_headers)
+    create_resp = await client.post("/api/agents", json={"name": "Bot", "human_operator": "Alice"}, headers=auth_headers)
     aicid = create_resp.json()["aicid"]
 
     work_resp = await client.post(


### PR DESCRIPTION
## Summary

- `human_operator` is now a required field in `AgentCreate` — the API returns HTTP 422 if it is missing or blank
- Added a Pydantic `field_validator` that rejects empty/whitespace-only values
- Added server-side validation to the public `/register` form handler for the same case
- Updated all tests that created agents without an operator name, and added two new tests covering the rejection cases
- Updated `docs/SKILL.md` to document the requirement

## Test plan

- [ ] `test_create_agent_without_operator_rejected` — POST without `human_operator` returns 422
- [ ] `test_create_agent_empty_operator_rejected` — POST with `human_operator: "  "` returns 422
- [ ] All 24 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)