### PR TITLE
Fix operator name display: subtitle below H1 with badge

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -174,7 +174,8 @@ main { flex: 1; }
 .agent-org, .agent-model { font-size: 0.9rem; color: var(--mid); margin: 0.4rem 0; }
 .agent-links { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem; font-size: 0.9rem; }
 
-.agent-name { font-size: 2rem; margin-bottom: 0.75rem; }
+.agent-name { font-size: 2rem; margin-bottom: 0.25rem; }
+.agent-operator { font-size: 1rem; color: #555; margin-bottom: 0.75rem; }
 .keywords { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
 .keyword-tag {
   background: #e8f4c0;

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -28,7 +28,10 @@
   </aside>
 
   <div class="profile-main">
-    <h1 class="agent-name">{{ agent.name }}{% if agent.human_operator %} operated by <span class="badge badge-operator">{{ agent.human_operator }}</span>{% endif %}</h1>
+    <h1 class="agent-name">{{ agent.name }}</h1>
+    {% if agent.human_operator %}
+    <p class="agent-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></p>
+    {% endif %}
 
     {% if agent.keywords %}
     <div class="keywords">

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -145,5 +145,5 @@ async def test_public_profile_shows_agent_type_and_operator(client: AsyncClient,
     assert 'class="badge badge-operator"' in resp.text
     assert "Co Scientist" in resp.text
     assert "operated by" in resp.text
-    assert "CopilotBot operated by" in resp.text
+    assert "CopilotBot" in resp.text
     assert "Martin Monperrus" in resp.text


### PR DESCRIPTION
## Summary
- Moves "operated by <operator>" out of the H1 into a `<p class="agent-operator">` subtitle directly below it
- Fixes the size mismatch where the H1 text was 2rem and the badge inside it was 0.8rem (root-relative)
- The `badge-operator` (purple) background now renders correctly at normal text size
- Adds `.agent-operator` CSS rule (1rem, muted color)
- Updates test: removes the `"CopilotBot operated by"` continuous-string check (now split across two elements)

## Test plan
- [ ] All 24 tests pass
- [ ] Profile page shows agent name in large H1, then "operated by <purple-badge>Name</purple-badge>" as a readable subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)