### PR TITLE
Style agent name and operator as same-line colored badges in H1

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -174,8 +174,10 @@ main { flex: 1; }
 .agent-org, .agent-model { font-size: 0.9rem; color: var(--mid); margin: 0.4rem 0; }
 .agent-links { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem; font-size: 0.9rem; }
 
-.agent-name { font-size: 2rem; margin-bottom: 0.25rem; }
-.agent-operator { font-size: 1rem; color: #555; margin-bottom: 0.75rem; }
+.agent-name-row { font-size: 1.6rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+.agent-name { display: inline-block; background: #e8f4c0; color: #3a5215; padding: 0.15rem 0.5rem; border-radius: var(--radius); }
+.agent-operator { color: #555; font-size: 1rem; }
+.agent-operator .badge { font-size: 1.6rem; }
 .keywords { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
 .keyword-tag {
   background: #e8f4c0;

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -28,10 +28,12 @@
   </aside>
 
   <div class="profile-main">
-    <h1 class="agent-name">{{ agent.name }}</h1>
-    {% if agent.human_operator %}
-    <p class="agent-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></p>
-    {% endif %}
+    <h1 class="agent-name-row">
+      <span class="agent-name">{{ agent.name }}</span>
+      {% if agent.human_operator %}
+      <span class="agent-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></span>
+      {% endif %}
+    </h1>
 
     {% if agent.keywords %}
     <div class="keywords">

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -141,6 +141,8 @@ async def test_public_profile_shows_agent_type_and_operator(client: AsyncClient,
     aicid = create_resp.json()["aicid"]
     resp = await client.get(f"/agents/{aicid}")
     assert resp.status_code == 200
+    assert 'class="agent-name-row"' in resp.text
+    assert 'class="agent-name"' in resp.text
     assert 'class="badge badge-type"' in resp.text
     assert 'class="badge badge-operator"' in resp.text
     assert "Co Scientist" in resp.text


### PR DESCRIPTION
## Summary
- Wraps the H1 in `agent-name-row` (flex row) so agent name and operator appear on the same line
- Agent name gets a green background badge; operator name keeps its purple badge
- "operated by" connector text is smaller (1rem) while both badges are 1.6rem
- Updates test to assert `agent-name-row` and `agent-name` classes are present

## Test plan
- [ ] All 24 tests pass
- [ ] Profile shows: `[green: GitHub Copilot CLI]  operated by  [purple: Martin Monperrus]` on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)