### PR TITLE
Include human_operator in public JSON profile endpoint

### DIFF
--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -78,6 +78,7 @@ async def public_profile_json(aicid: str, db: AsyncSession = Depends(get_db)):
         "aicid": agent.aicid,
         "name": agent.name,
         "agent_type": agent.agent_type,
+        "human_operator": agent.human_operator,
         "base_model": agent.base_model,
         "version": agent.version,
         "organization": agent.organization,

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -123,7 +123,9 @@ async def test_public_profile_json(client: AsyncClient, auth_headers: dict):
     aicid = create_resp.json()["aicid"]
     resp = await client.get(f"/agents/{aicid}/json")
     assert resp.status_code == 200
-    assert resp.json()["aicid"] == aicid
+    data = resp.json()
+    assert data["aicid"] == aicid
+    assert data["human_operator"] == "Alice"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `human_operator` was missing from the `/agents/{aicid}/json` response dict — it was stored in the DB and shown in the HTML profile but omitted from the JSON endpoint
- Adds `human_operator` to the returned JSON object
- Updates `test_public_profile_json` to assert the field is present and correct

## Test plan
- [ ] All 24 tests pass
- [ ] `GET /agents/{aicid}/json` now includes `"human_operator": "..."` in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)