### PR TITLE
Fix padding-top gap above agent name row

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -174,7 +174,7 @@ main { flex: 1; }
 .agent-org, .agent-model { font-size: 0.9rem; color: var(--mid); margin: 0.4rem 0; }
 .agent-links { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem; font-size: 0.9rem; }
 
-.agent-name-row { font-size: 1.6rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+.agent-name-row { font-size: 1.6rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 0.75rem; padding-top: 0; }
 .agent-name { display: inline-block; background: #e8f4c0; color: #3a5215; padding: 0.15rem 0.5rem; border-radius: var(--radius); }
 .agent-operator { color: #555; font-size: 1rem; }
 .agent-operator .badge { font-size: 1.6rem; }


### PR DESCRIPTION
## Summary
- The global `h1 { padding-top: 2rem; }` rule was adding a large gap above the agent name on profile pages
- Adds `padding-top: 0` to `.agent-name-row` to override it

🤖 Generated with [Claude Code](https://claude.com/claude-code)