### PR TITLE
Add git-commit cache-busting to CSS URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
 
 from app.config import settings
 from app.database import engine, Base

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -13,7 +13,6 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -24,8 +23,9 @@ from app.schemas.oauth import OAuthClientCreate, OAuthClientCreated, OAuthClient
 from app.core.deps import get_current_user
 from app.core.security import hash_password, verify_password, decode_token
 
+from app.templating import templates
+
 router = APIRouter()
-templates = Jinja2Templates(directory="templates")
 
 VALID_SCOPES = {"read:agent", "write:agent", "read:works", "write:works"}
 TOKEN_LIFETIME_SECONDS = 3600

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, or_
 
@@ -15,11 +14,11 @@ from app.models.work import Work
 from app.models.employment import Employment
 from app.models.funding import Funding
 
+from app.templating import templates
+
 router = APIRouter()
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-_TEMPLATES_DIR = _PROJECT_ROOT / "templates"
 _SKILL_DOC_PATH = _PROJECT_ROOT / "docs" / "SKILL.md"
-templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/app/templating.py
+++ b/app/templating.py
@@ -1,0 +1,10 @@
+import subprocess
+from fastapi.templating import Jinja2Templates
+
+_git_rev = subprocess.run(
+    ["git", "rev-parse", "--short", "HEAD"],
+    capture_output=True, text=True,
+).stdout.strip() or "dev"
+
+templates = Jinja2Templates(directory="templates")
+templates.env.globals["cache_bust"] = _git_rev

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}AICID{% endblock %}</title>
-  <link rel="stylesheet" href="/static/css/style.css">
+  <link rel="stylesheet" href="/static/css/style.css?v={{ cache_bust }}">
 </head>
 <body>
   <div class="alpha-banner">


### PR DESCRIPTION
## Summary
- CSS was served as `/static/css/style.css` with no version — browsers cache it indefinitely, so users kept seeing stale styles after deploys
- Centralizes `Jinja2Templates` into `app/templating.py` with the git commit hash injected as `cache_bust`
- All routers now import the shared `templates` instance
- `base.html` uses `?v={{ cache_bust }}` so the URL changes on every deploy

## Test plan
- [ ] All 24 tests pass
- [ ] HTML source shows `style.css?v=<commit-hash>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)