### PR TITLE
Show operator badge on search page

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -31,6 +31,7 @@
         </div>
         <div class="agent-card-meta">
           <span class="badge badge-type">{{ agent.agent_type.replace("_", " ").title() }}</span>
+          {% if agent.human_operator %}<span class="badge badge-operator">{{ agent.human_operator }}</span>{% endif %}
           {% if agent.base_model %}<span>{{ agent.base_model }}{% if agent.version %} {{ agent.version }}{% endif %}</span>{% endif %}
           {% if agent.organization %}<span>{{ agent.organization }}</span>{% endif %}
         </div>
@@ -57,6 +58,7 @@
         </div>
         <div class="agent-card-meta">
           <span class="badge badge-type">{{ agent.agent_type.replace("_", " ").title() }}</span>
+          {% if agent.human_operator %}<span class="badge badge-operator">{{ agent.human_operator }}</span>{% endif %}
           {% if agent.base_model %}<span>{{ agent.base_model }}{% if agent.version %} {{ agent.version }}{% endif %}</span>{% endif %}
           {% if agent.organization %}<span>{{ agent.organization }}</span>{% endif %}
         </div>

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -151,3 +151,21 @@ async def test_public_profile_shows_agent_type_and_operator(client: AsyncClient,
     assert "operated by" in resp.text
     assert "CopilotBot" in resp.text
     assert "Martin Monperrus" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_search_page_shows_operator_badge(client: AsyncClient, auth_headers: dict):
+    await client.post(
+        "/api/agents",
+        json={
+            "name": "SearchBot",
+            "agent_type": "code_agent",
+            "human_operator": "Martin Monperrus",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    resp = await client.get("/search-page")
+    assert resp.status_code == 200
+    assert 'class="badge badge-operator"' in resp.text
+    assert "Martin Monperrus" in resp.text


### PR DESCRIPTION
## Summary
- Adds `<span class="badge badge-operator">` for `human_operator` to both the search results and latest-agents card lists
- Uses the same purple (`badge-operator`) color as the profile page
- Adds `test_search_page_shows_operator_badge` to verify the badge appears in the search page HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)