### PR TITLE
Restyle search cards: AICID first, green name, operator badge, no type badge

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -132,10 +132,7 @@ main { flex: 1; }
 .aicid-badge-sm {
   font-family: monospace;
   font-size: 0.78rem;
-  background: var(--green);
-  color: var(--dark);
-  padding: 0.2rem 0.5rem;
-  border-radius: 3px;
+  color: var(--mid);
   font-weight: 700;
 }
 
@@ -250,9 +247,11 @@ main { flex: 1; }
 }
 .agent-card-link:hover { background: var(--light); text-decoration: none; }
 .agent-card-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.4rem; flex-wrap: wrap; }
-.agent-card-name { font-weight: 700; font-size: 1.1rem; }
+.agent-card-name { font-weight: 700; font-size: 1.1rem; background: #e8f4c0; color: #3a5215; padding: 0.1rem 0.4rem; border-radius: var(--radius); }
 .agent-card-meta { display: flex; gap: 0.75rem; flex-wrap: wrap; font-size: 0.875rem; color: var(--mid); margin-bottom: 0.4rem; }
 .agent-card-desc { font-size: 0.9rem; color: var(--mid); }
+.agent-card-operator { font-size: 0.85rem; color: var(--mid); }
+.agent-card-operator .badge { font-size: 0.85rem; }
 
 .empty-state { color: var(--mid); font-style: italic; margin: 2rem 0; }
 

--- a/templates/search.html
+++ b/templates/search.html
@@ -26,12 +26,11 @@
     <li class="agent-card">
       <a href="/agents/{{ agent.aicid }}" class="agent-card-link">
         <div class="agent-card-header">
-          <span class="agent-card-name">{{ agent.name }}</span>
           <span class="aicid-badge-sm">{{ agent.aicid }}</span>
+          <span class="agent-card-name">{{ agent.name }}</span>
+          {% if agent.human_operator %}<span class="agent-card-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></span>{% endif %}
         </div>
         <div class="agent-card-meta">
-          <span class="badge badge-type">{{ agent.agent_type.replace("_", " ").title() }}</span>
-          {% if agent.human_operator %}<span class="badge badge-operator">{{ agent.human_operator }}</span>{% endif %}
           {% if agent.base_model %}<span>{{ agent.base_model }}{% if agent.version %} {{ agent.version }}{% endif %}</span>{% endif %}
           {% if agent.organization %}<span>{{ agent.organization }}</span>{% endif %}
         </div>
@@ -53,12 +52,11 @@
     <li class="agent-card">
       <a href="/agents/{{ agent.aicid }}" class="agent-card-link">
         <div class="agent-card-header">
-          <span class="agent-card-name">{{ agent.name }}</span>
           <span class="aicid-badge-sm">{{ agent.aicid }}</span>
+          <span class="agent-card-name">{{ agent.name }}</span>
+          {% if agent.human_operator %}<span class="agent-card-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></span>{% endif %}
         </div>
         <div class="agent-card-meta">
-          <span class="badge badge-type">{{ agent.agent_type.replace("_", " ").title() }}</span>
-          {% if agent.human_operator %}<span class="badge badge-operator">{{ agent.human_operator }}</span>{% endif %}
           {% if agent.base_model %}<span>{{ agent.base_model }}{% if agent.version %} {{ agent.version }}{% endif %}</span>{% endif %}
           {% if agent.organization %}<span>{{ agent.organization }}</span>{% endif %}
         </div>

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -167,5 +167,9 @@ async def test_search_page_shows_operator_badge(client: AsyncClient, auth_header
     )
     resp = await client.get("/search-page")
     assert resp.status_code == 200
+    assert 'class="aicid-badge-sm"' in resp.text
+    assert 'class="agent-card-name"' in resp.text
+    assert "operated by" in resp.text
     assert 'class="badge badge-operator"' in resp.text
     assert "Martin Monperrus" in resp.text
+    assert 'class="badge badge-type"' not in resp.text


### PR DESCRIPTION
## Summary
- AICID badge moved to first position in card header
- Agent name gets green background matching profile page
- "operated by <purple badge>" added inline next to agent name
- Removed "Autonomous Agent" type badge (redundant)
- AICID badge loses background color — plain monospace grey text

🤖 Generated with [Claude Code](https://claude.com/claude-code)