### PR TITLE
Add SSH public key auth (RFC 9421 HTTP Message Signatures)

### DIFF
--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -7,18 +7,32 @@ from app.database import get_db
 from app.core.security import decode_token
 from app.models.user import User
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
+# auto_error=False so that missing Bearer tokens don't immediately 401;
+# we fall through to HTTP signature auth instead.
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token", auto_error=False)
 
 
 async def get_current_user(
-    token: str = Depends(oauth2_scheme),
+    request: Request,
+    token: str | None = Depends(oauth2_scheme),
     db: AsyncSession = Depends(get_db),
 ) -> User:
+    # Try HTTP signature auth when Signature-Input header is present
+    if "signature-input" in request.headers:
+        from app.core.http_signature import verify_http_signature
+        user = await verify_http_signature(request, db)
+        if user is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+        return user
+
+    # Fall back to Bearer token
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
+    if not token:
+        raise credentials_exception
     email = decode_token(token, expected_type="access")
     if not email:
         raise credentials_exception

--- a/app/core/http_signature.py
+++ b/app/core/http_signature.py
@@ -1,0 +1,203 @@
+"""RFC 9421 HTTP Message Signature verification for SSH public keys (ed25519)."""
+
+import base64
+import hashlib
+import hmac
+import re
+import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import load_ssh_public_key
+from fastapi import HTTPException, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+MAX_SKEW_SECONDS = 300
+
+
+def compute_fingerprint(public_key_line: str) -> str:
+    """Return the SHA256 fingerprint matching `ssh-keygen -lf` output."""
+    parts = public_key_line.strip().split()
+    if len(parts) < 2:
+        raise ValueError("Invalid SSH public key format")
+    key_blob = base64.b64decode(parts[1])
+    digest = hashlib.sha256(key_blob).digest()
+    return "SHA256:" + base64.b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _parse_signature_input(header: str) -> tuple[str, list[str], dict[str, str], str]:
+    """
+    Parse the first label from a Signature-Input header.
+    Returns (label, components, params, raw_value_for_label).
+    raw_value_for_label is the structured-field value used as @signature-params.
+    """
+    # Match: label=(component-list)params
+    m = re.match(r'(\w+)=((?:\(.*?\))(?:;[^,]*)*)', header, re.DOTALL)
+    if not m:
+        raise ValueError("Cannot parse Signature-Input header")
+    label = m.group(1)
+    raw_value = m.group(2)
+
+    # Extract quoted component names from inner list
+    paren_m = re.match(r'\(([^)]*)\)', raw_value)
+    if not paren_m:
+        raise ValueError("Cannot parse component list in Signature-Input")
+    components = re.findall(r'"([^"]+)"', paren_m.group(1))
+
+    # Extract params after the closing paren
+    params_str = raw_value[paren_m.end():]
+    params: dict[str, str] = {}
+    for pm in re.finditer(r';(\w+)=(?:"([^"]*?)"|(\d+))', params_str):
+        key = pm.group(1)
+        val = pm.group(2) if pm.group(2) is not None else pm.group(3)
+        params[key] = val
+
+    return label, components, params, raw_value
+
+
+def _build_signature_base(components: list[str], sig_params_value: str, request: Request) -> bytes:
+    """Construct the RFC 9421 §2.5 signature base."""
+    lines: list[str] = []
+    for comp in components:
+        if comp == "@method":
+            lines.append(f'"@method": {request.method}')
+        elif comp == "@path":
+            lines.append(f'"@path": {request.url.path}')
+        elif comp == "@authority":
+            lines.append(f'"@authority": {request.url.hostname}')
+        else:
+            val = request.headers.get(comp)
+            if val is None:
+                raise ValueError(f"Required header '{comp}' missing from request")
+            lines.append(f'"{comp}": {val}')
+    lines.append(f'"@signature-params": {sig_params_value}')
+    return "\n".join(lines).encode("utf-8")
+
+
+async def _verify_content_digest(request: Request) -> None:
+    """Check Content-Digest (sha-256) against the actual request body."""
+    header = request.headers.get("content-digest")
+    if header is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="content-digest header required for requests with a body")
+    m = re.match(r'sha-256=:([A-Za-z0-9+/=]+):', header)
+    if not m:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="content-digest must use sha-256 algorithm")
+    try:
+        expected = base64.b64decode(m.group(1))
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid base64 in content-digest")
+    body = await request.body()
+    actual = hashlib.sha256(body).digest()
+    if not hmac.compare_digest(expected, actual):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Content-Digest mismatch")
+
+
+async def verify_http_signature(request: Request, db: AsyncSession) -> Optional["User"]:  # type: ignore[name-defined]
+    """
+    Authenticate via RFC 9421 HTTP Message Signature.
+    Returns User on success, None if signature headers are absent, raises 401 on failure.
+    """
+    from app.models.ssh_key import SSHKey
+    from app.models.user import User
+
+    sig_input_header = request.headers.get("signature-input")
+    sig_header = request.headers.get("signature")
+
+    if not sig_input_header or not sig_header:
+        return None
+
+    try:
+        label, components, params, raw_value = _parse_signature_input(sig_input_header)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid Signature-Input: {e}")
+
+    keyid = params.get("keyid")
+    alg = params.get("alg")
+    created_str = params.get("created")
+
+    if not keyid or not alg or not created_str:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature-Input must include keyid, alg, and created")
+
+    if alg != "ed25519":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Unsupported signature algorithm '{alg}'; only ed25519 is supported")
+
+    # Replay protection via created timestamp
+    try:
+        created = int(created_str)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="created parameter must be an integer Unix timestamp")
+
+    now = int(time.time())
+    if abs(now - created) > MAX_SKEW_SECONDS:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature too old or too far in future (max 5 minutes skew)")
+
+    # Date header replay check (belt-and-suspenders)
+    date_header = request.headers.get("date")
+    if date_header:
+        try:
+            date_dt = parsedate_to_datetime(date_header)
+            skew = abs(datetime.now(timezone.utc).timestamp() - date_dt.timestamp())
+            if skew > MAX_SKEW_SECONDS:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Date header too old or too far in future")
+        except HTTPException:
+            raise
+        except Exception:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Date header format")
+
+    # Extract the base64 signature value for this label
+    sig_m = re.search(rf'{re.escape(label)}=:([A-Za-z0-9+/=]+):', sig_header)
+    if not sig_m:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Signature label '{label}' not found in Signature header")
+    try:
+        sig_bytes = base64.b64decode(sig_m.group(1))
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid base64 in Signature header")
+
+    # Verify content-digest if it is a covered component
+    if "content-digest" in components:
+        await _verify_content_digest(request)
+
+    # Build signature base
+    try:
+        sig_base = _build_signature_base(components, raw_value, request)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(e))
+
+    # Look up the SSH key by fingerprint
+    result = await db.execute(
+        select(SSHKey).where(SSHKey.key_fingerprint == keyid, SSHKey.is_active.is_(True))
+    )
+    ssh_key = result.scalar_one_or_none()
+    if ssh_key is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown or inactive SSH key fingerprint")
+
+    # Load public key and verify
+    try:
+        pub_key = load_ssh_public_key(ssh_key.public_key.encode("utf-8"))
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Could not load SSH public key: {e}")
+
+    if not isinstance(pub_key, Ed25519PublicKey):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="SSH key is not an ed25519 key")
+
+    try:
+        pub_key.verify(sig_bytes, sig_base)
+    except InvalidSignature:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Signature verification failed")
+
+    # Record last use
+    ssh_key.last_used_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    # Fetch and return the user
+    user_result = await db.execute(
+        select(User).where(User.id == ssh_key.user_id, User.is_active.is_(True))
+    )
+    user = user_result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+    return user

--- a/app/main.py
+++ b/app/main.py
@@ -14,8 +14,9 @@ import app.models.employment  # noqa: F401
 import app.models.funding  # noqa: F401
 import app.models.oauth  # noqa: F401
 import app.models.auth_challenge  # noqa: F401
+import app.models.ssh_key  # noqa: F401
 
-from app.routers import auth, agents, works, employment, funding, search, public, oauth, manage  # noqa: F401
+from app.routers import auth, agents, works, employment, funding, search, public, oauth, manage, ssh_keys  # noqa: F401
 
 
 @asynccontextmanager
@@ -47,6 +48,7 @@ application.include_router(funding.router, prefix="/api/agents", tags=["funding"
 application.include_router(search.router, tags=["search"])
 application.include_router(oauth.router, prefix="/oauth", tags=["oauth"])
 application.include_router(manage.router, tags=["manage"])
+application.include_router(ssh_keys.router, prefix="/api/account", tags=["ssh-keys"])
 application.include_router(public.router, tags=["public"])
 
 # Alias for uvicorn entrypoint and imports

--- a/app/models/ssh_key.py
+++ b/app/models/ssh_key.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class SSHKey(Base):
+    __tablename__ = "ssh_keys"
+
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    public_key: Mapped[str] = mapped_column(Text, nullable=False)
+    key_fingerprint: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_used_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    owner = relationship("User", back_populates="ssh_keys")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -19,3 +19,4 @@ class User(Base):
 
     agents = relationship("Agent", back_populates="owner", cascade="all, delete-orphan")
     oauth_clients = relationship("OAuthClient", back_populates="owner", cascade="all, delete-orphan")
+    ssh_keys = relationship("SSHKey", back_populates="owner", cascade="all, delete-orphan")

--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -6,9 +6,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
+from app.core.http_signature import compute_fingerprint
 from app.core.security import decode_token
 from app.database import get_db
 from app.models.agent import Agent
+from app.models.ssh_key import SSHKey
 from app.models.user import User
 from app.templating import templates
 
@@ -97,3 +99,80 @@ async def update_agent_from_browser(
 
     await db.commit()
     return RedirectResponse(url=f"/manage?updated={aicid}", status_code=303)
+
+
+@router.get("/manage/settings", response_class=HTMLResponse)
+async def settings_page(
+    request: Request,
+    error: str | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _get_browser_user(request, db)
+    if user is None:
+        return _login_redirect("/manage/settings")
+
+    result = await db.execute(
+        select(SSHKey).where(SSHKey.user_id == user.id).order_by(SSHKey.created_at.desc())
+    )
+    ssh_keys = result.scalars().all()
+    return templates.TemplateResponse(
+        "settings.html",
+        {"request": request, "user": user, "ssh_keys": ssh_keys, "error": error},
+    )
+
+
+@router.post("/manage/settings/ssh-keys/add")
+async def add_ssh_key_browser(
+    request: Request,
+    label: str = Form(...),
+    public_key: str = Form(...),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _get_browser_user(request, db)
+    if user is None:
+        return _login_redirect("/manage/settings")
+
+    public_key = public_key.strip()
+    parts = public_key.split()
+    allowed_types = ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521")
+    if len(parts) < 2 or parts[0] not in allowed_types:
+        return RedirectResponse(url="/manage/settings?error=Invalid+SSH+public+key+format", status_code=303)
+
+    try:
+        fingerprint = compute_fingerprint(public_key)
+    except Exception:
+        return RedirectResponse(url="/manage/settings?error=Could+not+parse+public+key", status_code=303)
+
+    existing = await db.execute(select(SSHKey).where(SSHKey.key_fingerprint == fingerprint))
+    if existing.scalar_one_or_none() is not None:
+        return RedirectResponse(url="/manage/settings?error=A+key+with+this+fingerprint+already+exists", status_code=303)
+
+    db.add(SSHKey(
+        user_id=user.id,
+        label=label.strip(),
+        public_key=public_key,
+        key_fingerprint=fingerprint,
+        is_active=True,
+    ))
+    await db.commit()
+    return RedirectResponse(url="/manage/settings", status_code=303)
+
+
+@router.post("/manage/settings/ssh-keys/{key_id}/delete")
+async def delete_ssh_key_browser(
+    request: Request,
+    key_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _get_browser_user(request, db)
+    if user is None:
+        return _login_redirect("/manage/settings")
+
+    result = await db.execute(
+        select(SSHKey).where(SSHKey.id == key_id, SSHKey.user_id == user.id)
+    )
+    key = result.scalar_one_or_none()
+    if key:
+        await db.delete(key)
+        await db.commit()
+    return RedirectResponse(url="/manage/settings", status_code=303)

--- a/app/routers/ssh_keys.py
+++ b/app/routers/ssh_keys.py
@@ -1,0 +1,69 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import get_current_user
+from app.core.http_signature import compute_fingerprint
+from app.database import get_db
+from app.models.ssh_key import SSHKey
+from app.models.user import User
+from app.schemas.ssh_key import SSHKeyCreate, SSHKeyRead
+
+router = APIRouter()
+
+
+@router.get("/ssh-keys", response_model=List[SSHKeyRead])
+async def list_ssh_keys(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(SSHKey).where(SSHKey.user_id == current_user.id).order_by(SSHKey.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/ssh-keys", response_model=SSHKeyRead, status_code=status.HTTP_201_CREATED)
+async def add_ssh_key(
+    body: SSHKeyCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    try:
+        fingerprint = compute_fingerprint(body.public_key)
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Could not parse public key: {e}")
+
+    existing = await db.execute(select(SSHKey).where(SSHKey.key_fingerprint == fingerprint))
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="A key with this fingerprint already exists")
+
+    key = SSHKey(
+        user_id=current_user.id,
+        label=body.label.strip(),
+        public_key=body.public_key.strip(),
+        key_fingerprint=fingerprint,
+        is_active=True,
+    )
+    db.add(key)
+    await db.commit()
+    await db.refresh(key)
+    return key
+
+
+@router.delete("/ssh-keys/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_ssh_key(
+    key_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    result = await db.execute(
+        select(SSHKey).where(SSHKey.id == key_id, SSHKey.user_id == current_user.id)
+    )
+    key = result.scalar_one_or_none()
+    if key is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="SSH key not found")
+    await db.delete(key)
+    await db.commit()

--- a/app/schemas/ssh_key.py
+++ b/app/schemas/ssh_key.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+
+class SSHKeyCreate(BaseModel):
+    label: str
+    public_key: str
+
+    @field_validator("public_key")
+    @classmethod
+    def validate_key_format(cls, v: str) -> str:
+        v = v.strip()
+        parts = v.split()
+        if len(parts) < 2 or parts[0] not in ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521"):
+            raise ValueError("public_key must be a valid OpenSSH public key (ssh-ed25519, ssh-rsa, or ecdsa-*)")
+        return v
+
+
+class SSHKeyRead(BaseModel):
+    id: int
+    label: str
+    key_fingerprint: str
+    is_active: bool
+    last_used_at: Optional[datetime]
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/migrations/versions/004_add_ssh_keys.py
+++ b/migrations/versions/004_add_ssh_keys.py
@@ -1,0 +1,38 @@
+"""add ssh keys
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-06-16
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ssh_keys",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("label", sa.String(255), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("key_fingerprint", sa.String(100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_ssh_keys_user_id", "ssh_keys", ["user_id"])
+    op.create_index("ix_ssh_keys_key_fingerprint", "ssh_keys", ["key_fingerprint"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ssh_keys_key_fingerprint", table_name="ssh_keys")
+    op.drop_index("ix_ssh_keys_user_id", table_name="ssh_keys")
+    op.drop_table("ssh_keys")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ alembic==1.14.0
 asyncpg==0.30.0  # async Postgres driver used for Supabase connections
 psycopg2-binary==2.9.10
 python-jose[cryptography]==3.3.0
+cryptography>=43.0.0
 bcrypt==4.3.0
 python-multipart==0.0.20
 pydantic[email]==2.10.3

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
       <nav class="site-nav">
         <a href="/search-page">Search</a>
         <a href="/manage">Manage</a>
+        <a href="/manage/settings">Settings</a>
         <a href="/docs">Docs</a>
         <a href="https://github.com/4open-science/aicid-net" target="_blank">GitHub</a>
       </nav>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+{% block title %}Settings — AICID{% endblock %}
+
+{% block content %}
+<div class="container manage-page">
+  <div class="manage-header">
+    <div>
+      <h1>Account Settings</h1>
+      <p>Signed in as <strong>{{ user.email }}</strong>.</p>
+    </div>
+    <div style="display:flex;gap:0.75rem;align-items:center">
+      <a href="/manage" class="btn btn-outline-dark">Back to dashboard</a>
+      <form method="post" action="/auth/logout">
+        <button type="submit" class="btn btn-outline-dark">Sign Out</button>
+      </form>
+    </div>
+  </div>
+
+  <section class="manage-card" style="margin-bottom:2rem">
+    <div class="manage-card-header">
+      <h2>SSH Public Keys</h2>
+    </div>
+    <p style="margin:0 0 1rem">
+      SSH keys allow you to authenticate API requests without a bearer token by signing
+      HTTP requests (RFC 9421). The <code>keyid</code> is your key's SHA-256 fingerprint
+      (<code>ssh-keygen -lf your_key.pub</code>).
+    </p>
+
+    {% if error %}
+    <div class="form-error" style="margin-bottom:1rem">{{ error }}</div>
+    {% endif %}
+
+    {% if ssh_keys %}
+    <table style="width:100%;border-collapse:collapse;margin-bottom:1.5rem">
+      <thead>
+        <tr style="text-align:left;border-bottom:1px solid #e0e0e0">
+          <th style="padding:0.5rem 0.75rem">Label</th>
+          <th style="padding:0.5rem 0.75rem">Fingerprint</th>
+          <th style="padding:0.5rem 0.75rem">Added</th>
+          <th style="padding:0.5rem 0.75rem">Last used</th>
+          <th style="padding:0.5rem 0.75rem"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for key in ssh_keys %}
+        <tr style="border-bottom:1px solid #f0f0f0">
+          <td style="padding:0.5rem 0.75rem">{{ key.label }}</td>
+          <td style="padding:0.5rem 0.75rem;font-family:monospace;font-size:0.8rem">{{ key.key_fingerprint }}</td>
+          <td style="padding:0.5rem 0.75rem;font-size:0.85rem">{{ key.created_at.strftime('%Y-%m-%d') }}</td>
+          <td style="padding:0.5rem 0.75rem;font-size:0.85rem">
+            {% if key.last_used_at %}{{ key.last_used_at.strftime('%Y-%m-%d') }}{% else %}Never{% endif %}
+          </td>
+          <td style="padding:0.5rem 0.75rem">
+            <form method="post" action="/manage/settings/ssh-keys/{{ key.id }}/delete"
+                  onsubmit="return confirm('Remove this SSH key?')">
+              <button type="submit" class="btn btn-outline-dark" style="font-size:0.8rem;padding:0.2rem 0.6rem">Remove</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <p class="empty-state" style="margin-bottom:1.5rem">No SSH keys registered yet.</p>
+    {% endif %}
+
+    <details>
+      <summary style="cursor:pointer;font-weight:600;margin-bottom:0.75rem">Add a new SSH key</summary>
+      <form method="post" action="/manage/settings/ssh-keys/add" style="margin-top:0.75rem">
+        <div class="manage-fields">
+          <div class="form-group">
+            <label for="key-label">Label</label>
+            <input id="key-label" name="label" placeholder="e.g. my-laptop" required>
+          </div>
+          <div class="form-group form-group-wide">
+            <label for="key-value">Public key</label>
+            <textarea id="key-value" name="public_key" rows="3"
+              placeholder="ssh-ed25519 AAAA... user@host" required
+              style="font-family:monospace;font-size:0.85rem"></textarea>
+            <small style="color:#666">Paste the contents of your <code>~/.ssh/id_ed25519.pub</code> (or equivalent).</small>
+          </div>
+        </div>
+        <div class="manage-card-actions">
+          <button type="submit" class="btn btn-primary">Add SSH key</button>
+        </div>
+      </form>
+    </details>
+  </section>
+
+  <section class="manage-card">
+    <div class="manage-card-header">
+      <h2>Using SSH key authentication</h2>
+    </div>
+    <p>Sign API requests with your SSH private key. Include these headers on every request:</p>
+    <pre style="background:#f6f8fa;padding:1rem;border-radius:6px;overflow-x:auto;font-size:0.8rem"><code>Signature-Input: sig1=("@method" "@path" "@authority" "date");keyid="&lt;YOUR_FINGERPRINT&gt;";alg="ed25519";created=&lt;UNIX_TIMESTAMP&gt;
+Signature: sig1=:&lt;BASE64_SIGNATURE&gt;:
+Date: &lt;RFC7231_DATE&gt;</code></pre>
+    <p>For <code>POST</code>/<code>PUT</code>/<code>PATCH</code> requests also include:</p>
+    <pre style="background:#f6f8fa;padding:1rem;border-radius:6px;overflow-x:auto;font-size:0.8rem"><code>Content-Digest: sha-256=:&lt;BASE64_SHA256_OF_BODY&gt;:</code></pre>
+    <p style="font-size:0.9rem">
+      The signature covers the <strong>RFC 9421 signature base</strong> constructed from the listed components.
+      See <a href="/docs">the docs</a> or <a href="https://www.rfc-editor.org/rfc/rfc9421" target="_blank">RFC 9421</a> for details.
+    </p>
+  </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- Users can register ed25519 SSH public keys via the management UI (`/manage/settings`) or the API (`POST /api/account/ssh-keys`)
- API requests can authenticate without a bearer token by signing the HTTP message with their SSH private key, following [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)
- Replay protection via `created` timestamp (±5 min skew); `Content-Digest` verified when it is a covered component

## New endpoints

| Method | Path | Description |
|---|---|---|
| `GET` | `/api/account/ssh-keys` | List your SSH keys |
| `POST` | `/api/account/ssh-keys` | Add an SSH key |
| `DELETE` | `/api/account/ssh-keys/{id}` | Remove an SSH key |
| `GET` | `/manage/settings` | Settings UI |

## Authentication flow

Include these headers on every API request instead of `Authorization: Bearer`:

```
Date: <RFC 7231 date>
Signature-Input: sig1=("@method" "@path" "@authority" "date");keyid="SHA256:<fingerprint>";alg="ed25519";created=<unix-ts>
Signature: sig1=:<base64-ed25519-sig>:
```

For requests with a body, also add:
```
Content-Digest: sha-256=:<base64-sha256-of-body>:
```

The `keyid` is the SHA-256 fingerprint from `ssh-keygen -lf your_key.pub`.

## Test plan

- [ ] Register an ed25519 key via UI and verify it appears in the list with the correct fingerprint
- [ ] Add/delete a key via the API with a bearer token
- [ ] Make a `GET` API call signed with the SSH private key and verify it succeeds
- [ ] Replay: re-send the same request with a stale `created` value and verify 401
- [ ] Wrong signature: mutate one byte and verify 401
- [ ] Unknown `keyid`: verify 401
- [ ] Existing Bearer token auth still works unchanged

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)