### PR TITLE
Switch to blue color scheme and logo

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,7 +1,7 @@
-/* AICID — ORCID-inspired stylesheet */
+/* AICID stylesheet */
 :root {
-  --green: #a6ce39;
-  --green-dark: #7aaa1e;
+  --blue: #4a9fd5;
+  --blue-dark: #005cb1;
   --dark: #2c2c2c;
   --mid: #555;
   --light: #f5f5f5;
@@ -23,7 +23,7 @@ body {
   min-height: 100vh;
 }
 
-a { color: var(--green-dark); text-decoration: none; }
+a { color: var(--blue-dark); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 .container { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem; }
@@ -58,7 +58,7 @@ a:hover { text-decoration: underline; }
 }
 .header-inner { display: flex; align-items: center; justify-content: space-between; }
 .logo { display: flex; align-items: center; gap: 0.5rem; color: var(--white); font-size: 1.4rem; font-weight: 700; }
-.logo-icon { color: var(--green); font-size: 1.6rem; }
+.logo-img { height: 2rem; width: auto; }
 .site-nav { display: flex; gap: 1.5rem; }
 .site-nav a { color: #ccc; font-size: 0.95rem; }
 .site-nav a:hover { color: var(--white); text-decoration: none; }
@@ -78,13 +78,13 @@ main { flex: 1; }
 
 /* Hero */
 .hero {
-  background: linear-gradient(135deg, #1a2a0a 0%, #2c3e10 60%, #3a5215 100%);
+  background: linear-gradient(135deg, #0a1a3a 0%, #0d2a5e 60%, #1040a0 100%);
   color: var(--white);
   padding: 5rem 0 4rem;
   text-align: center;
 }
 .hero h1 { font-size: 2.8rem; font-weight: 700; line-height: 1.2; margin-bottom: 1.2rem; }
-.hero h1 .accent { color: var(--green); }
+.hero h1 .accent { color: var(--blue); }
 .hero-sub { font-size: 1.15rem; color: #ccc; max-width: 600px; margin: 0 auto 2rem; }
 .hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-bottom: 2rem; }
 .aicid-example { margin-top: 1rem; }
@@ -100,8 +100,8 @@ main { flex: 1; }
   border: 2px solid transparent;
   transition: background 0.15s, color 0.15s;
 }
-.btn-primary { background: var(--green); color: var(--dark); }
-.btn-primary:hover { background: var(--green-dark); text-decoration: none; }
+.btn-primary { background: var(--blue); color: var(--white); }
+.btn-primary:hover { background: var(--blue-dark); text-decoration: none; }
 .btn-outline { background: transparent; color: var(--white); border-color: var(--white); }
 .btn-outline:hover { background: rgba(255,255,255,0.1); text-decoration: none; }
 .btn-outline-dark { background: transparent; color: var(--dark); border-color: var(--dark); }
@@ -110,8 +110,8 @@ main { flex: 1; }
 /* AICID badge */
 .aicid-badge {
   display: inline-block;
-  background: var(--green);
-  color: var(--dark);
+  background: var(--blue);
+  color: var(--white);
   font-family: monospace;
   font-size: 1.1rem;
   font-weight: 700;
@@ -121,8 +121,8 @@ main { flex: 1; }
 }
 .aicid-badge-large {
   display: inline-block;
-  background: var(--green);
-  color: var(--dark);
+  background: var(--blue);
+  color: var(--white);
   font-family: monospace;
   font-size: 0.9rem;
   font-weight: 700;
@@ -174,13 +174,13 @@ main { flex: 1; }
 .agent-links { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem; font-size: 0.9rem; }
 
 .agent-name-row { font-size: 1.6rem; display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 0.75rem; padding-top: 0; }
-.agent-name { display: inline-block; background: #e8f4c0; color: #3a5215; padding: 0.15rem 0.5rem; border-radius: var(--radius); }
+.agent-name { display: inline-block; background: #d0e8f8; color: #005cb1; padding: 0.15rem 0.5rem; border-radius: var(--radius); }
 .agent-operator { color: #555; font-size: 1rem; }
 .agent-operator .badge { font-size: 1.6rem; }
 .keywords { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1.5rem; }
 .keyword-tag {
-  background: #e8f4c0;
-  color: #3a5215;
+  background: #d0e8f8;
+  color: #005cb1;
   padding: 0.2rem 0.6rem;
   border-radius: 20px;
   font-size: 0.85rem;
@@ -190,7 +190,7 @@ main { flex: 1; }
 .profile-section h2 {
   font-size: 1.2rem;
   color: var(--mid);
-  border-bottom: 2px solid var(--green);
+  border-bottom: 2px solid var(--blue);
   padding-bottom: 0.4rem;
   margin-bottom: 1rem;
   text-transform: uppercase;
@@ -220,7 +220,7 @@ main { flex: 1; }
 .badge-type { background: #e0f0ff; color: #1a5fa8; }
 .badge-operator { background: #f0e8ff; color: #5a1a8a; }
 .badge-limited { background: #fff0cc; color: #8a5c00; }
-.badge-work-type { background: #e8f4c0; color: #3a5215; margin-right: 0.4rem; }
+.badge-work-type { background: #d0e8f8; color: #005cb1; margin-right: 0.4rem; }
 
 /* Search */
 .search-form { display: flex; gap: 0.75rem; margin: 2rem 0 1.5rem; flex-wrap: wrap; }
@@ -232,7 +232,7 @@ main { flex: 1; }
   border-radius: var(--radius);
   font-size: 1rem;
 }
-.search-input:focus { outline: none; border-color: var(--green); }
+.search-input:focus { outline: none; border-color: var(--blue); }
 .search-meta { color: var(--mid); font-size: 0.9rem; margin-bottom: 1rem; }
 
 .agent-list { list-style: none; display: flex; flex-direction: column; gap: 1rem; }
@@ -249,7 +249,7 @@ main { flex: 1; }
 }
 .agent-card-link:hover { background: var(--light); text-decoration: none; }
 .agent-card-header { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.4rem; flex-wrap: wrap; }
-.agent-card-name { font-weight: 700; font-size: 1.1rem; background: #e8f4c0; color: #3a5215; padding: 0.1rem 0.4rem; border-radius: var(--radius); }
+.agent-card-name { font-weight: 700; font-size: 1.1rem; background: #d0e8f8; color: #005cb1; padding: 0.1rem 0.4rem; border-radius: var(--radius); }
 .agent-card-meta { display: flex; gap: 0.75rem; flex-wrap: wrap; font-size: 0.875rem; color: var(--mid); margin-bottom: 0.4rem; }
 .agent-card-desc { font-size: 0.9rem; color: var(--mid); }
 .agent-card-operator { font-size: 0.85rem; color: var(--mid); }
@@ -279,9 +279,9 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
 }
 
 .form-success {
-  background: #eef8db;
-  border: 1px solid #c8df8a;
-  color: #3a5215;
+  background: #d8eef8;
+  border: 1px solid #8ac8e8;
+  color: #005cb1;
   border-radius: var(--radius);
   padding: 0.75rem 1rem;
   margin-bottom: 1.5rem;
@@ -338,11 +338,11 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
 }
 .form-group input:focus {
   outline: none;
-  border-color: var(--green);
+  border-color: var(--blue);
 }
 .form-group textarea:focus {
   outline: none;
-  border-color: var(--green);
+  border-color: var(--blue);
 }
 
 .form-hint { font-size: 0.85rem; color: var(--mid); }
@@ -354,8 +354,8 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
   margin-top: 1rem;
   padding: 0.75rem 1rem;
   border-radius: var(--radius);
-  background: #f6f8ed;
-  color: #3a5215;
+  background: #e8f3fb;
+  color: #005cb1;
 }
 
 .verify-form { margin-top: 1.25rem; }
@@ -478,7 +478,7 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
 }
 .docs-section h2 {
   font-size: 1.6rem;
-  border-bottom: 3px solid var(--green);
+  border-bottom: 3px solid var(--blue);
   padding-bottom: 0.4rem;
   margin-bottom: 1.2rem;
 }
@@ -505,8 +505,8 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
   gap: 0.3rem;
 }
 .docs-section pre {
-  background: #1e2a10;
-  color: #d4e8a0;
+  background: #0a1a3a;
+  color: #a0d0f0;
   border-radius: var(--radius);
   padding: 1rem 1.25rem;
   overflow-x: auto;
@@ -517,8 +517,8 @@ h1 { padding-top: 2rem; margin-bottom: 1rem; }
 .docs-section code {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.875em;
-  background: #f0f4e8;
-  color: #3a5215;
+  background: #e0f0f8;
+  color: #005cb1;
   padding: 0.15em 0.4em;
   border-radius: 3px;
 }

--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="55.285061mm"
+   height="63.837688mm"
+   viewBox="0 0 55.285061 63.837688"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="logo_blue.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="4.0840585"
+     inkscape:cx="157.56385"
+     inkscape:cy="215.22708"
+     inkscape:window-width="3840"
+     inkscape:window-height="2027"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-77.35747,-116.58116)">
+    <path
+       sodipodi:type="star"
+       style="fill:#005cb1;fill-opacity:1;stroke-width:0"
+       id="path2"
+       inkscape:flatsided="true"
+       sodipodi:sides="6"
+       sodipodi:cx="66.721672"
+       sodipodi:cy="51.665009"
+       sodipodi:r1="31.918844"
+       sodipodi:r2="27.642529"
+       sodipodi:arg1="1.5707963"
+       sodipodi:arg2="2.0943951"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 66.721673,83.583853 -27.64253,-15.959422 -1e-6,-31.918844 27.642529,-15.959423 27.642531,15.959422 0,31.918844 z"
+       transform="translate(38.278328,96.834996)" />
+    <text
+       xml:space="preserve"
+       style="font-weight:600;font-size:40.5694px;font-family:Rajdhani;-inkscape-font-specification:'Rajdhani Semi-Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#a6ce39;fill-opacity:1;stroke-width:0"
+       x="104.89019"
+       y="163.44121"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40.5694px;font-family:Roboto;-inkscape-font-specification:Roboto;fill:#ffffff;stroke-width:0"
+         x="104.89019"
+         y="163.44121">AI</tspan></text>
+    <circle
+       style="fill:#ffffff;stroke-width:0"
+       id="path1"
+       cx="118.21288"
+       cy="130.07587"
+       r="2.3388693" />
+  </g>
+</svg>

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
   <header class="site-header">
     <div class="container header-inner">
       <a href="/" class="logo">
-        <span class="logo-icon">⬡</span>
+        <img src="/static/logo.svg" alt="AICID logo" class="logo-img">
         <span class="logo-text">AICID</span>
       </a>
       <nav class="site-nav">


### PR DESCRIPTION
## Summary
- Replace green palette (`#a6ce39`/`#7aaa1e`) with blue (`#4a9fd5`/`#005cb1`) across all CSS variables, badges, gradients, buttons, and code blocks
- Swap hexagon emoji in header for the blue SVG logo (`static/logo.svg`)

## Test plan
- [ ] Home page hero gradient is dark blue
- [ ] Header logo renders the SVG
- [ ] Buttons, badges, and highlights are blue
- [ ] Search input focus ring is blue
- [ ] Profile section borders are blue
- [ ] Docs code blocks use navy/blue theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)