### PR TITLE
Add operator_orcid field to agents

### DIFF
--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -16,6 +16,7 @@ class Agent(Base):
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     human_operator: Mapped[Optional[str]] = mapped_column(String(255))
+    operator_orcid: Mapped[Optional[str]] = mapped_column(String(500))
     agent_harness: Mapped[Optional[str]] = mapped_column(String(255))
     agent_type: Mapped[str] = mapped_column(
         String(50), nullable=False, default="autonomous_agent"

--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -61,6 +61,7 @@ async def update_agent_from_browser(
     aicid: str,
     name: str = Form(...),
     human_operator: str = Form(...),
+    operator_orcid: str = Form(""),
     agent_harness: str = Form(""),
     agent_type: str = Form("autonomous_agent"),
     base_model: str = Form(""),
@@ -85,6 +86,7 @@ async def update_agent_from_browser(
 
     agent.name = name.strip()
     agent.human_operator = human_operator.strip()
+    agent.operator_orcid = operator_orcid.strip() or None
     agent.agent_harness = agent_harness.strip() or None
     agent.agent_type = agent_type.strip() or "autonomous_agent"
     agent.base_model = base_model.strip() or None

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, field_validator
 class AgentCreate(BaseModel):
     name: str
     human_operator: str
+    operator_orcid: Optional[str] = None
 
     @field_validator("human_operator")
     @classmethod
@@ -30,6 +31,7 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     human_operator: Optional[str] = None
+    operator_orcid: Optional[str] = None
     agent_harness: Optional[str] = None
     agent_type: Optional[str] = None
     base_model: Optional[str] = None
@@ -49,6 +51,7 @@ class AgentRead(BaseModel):
     owner_id: int
     name: str
     human_operator: Optional[str]
+    operator_orcid: Optional[str]
     agent_harness: Optional[str]
     agent_type: str
     base_model: Optional[str]

--- a/migrations/versions/005_add_operator_orcid.py
+++ b/migrations/versions/005_add_operator_orcid.py
@@ -1,0 +1,24 @@
+"""add operator_orcid to agents
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-07-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("operator_orcid", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "operator_orcid")

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -39,6 +39,10 @@
             <input id="human-{{ agent.aicid }}" name="human_operator" value="{{ agent.human_operator or '' }}" required>
           </div>
           <div class="form-group">
+            <label for="orcid-{{ agent.aicid }}">Operator ORCID</label>
+            <input id="orcid-{{ agent.aicid }}" name="operator_orcid" value="{{ agent.operator_orcid or '' }}" placeholder="https://orcid.org/0000-0000-0000-0000">
+          </div>
+          <div class="form-group">
             <label for="harness-{{ agent.aicid }}">Agent Harness</label>
             <input id="harness-{{ agent.aicid }}" name="agent_harness" value="{{ agent.agent_harness or '' }}">
           </div>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -32,7 +32,13 @@
     <h1 class="agent-name-row">
       <span class="agent-name">{{ agent.name }}</span>
       {% if agent.human_operator %}
-      <span class="agent-operator">operated by <span class="badge badge-operator">{{ agent.human_operator }}</span></span>
+      <span class="agent-operator">operated by
+        {% if agent.operator_orcid %}
+          <a href="{{ agent.operator_orcid }}" target="_blank" rel="noopener" class="badge badge-operator">{{ agent.human_operator }}</a>
+        {% else %}
+          <span class="badge badge-operator">{{ agent.human_operator }}</span>
+        {% endif %}
+      </span>
       {% endif %}
     </h1>
 


### PR DESCRIPTION
Closes #1

## Changes

- `Agent` model: new `operator_orcid` column (`String(500)`, nullable)
- `AgentCreate` / `AgentUpdate` / `AgentRead` schemas: expose `operator_orcid`
- Manage UI (`/manage`): editable input field with ORCID placeholder
- Public profile page: operator name renders as a clickable ORCID link when the field is set
- Migration `005_add_operator_orcid`: `ALTER TABLE agents ADD COLUMN operator_orcid`