### PR TITLE
Add ORCID Verified support for agent operators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,12 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Validate dependency graph
+        run: pip check
 
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/app/config.py
+++ b/app/config.py
@@ -23,5 +23,9 @@ class Settings(BaseSettings):
     POSTHORN_PATH: str = "/api/send"
     SESSION_COOKIE_NAME: str = "aicid_session"
 
+    ORCID_CLIENT_ID: str | None = None
+    ORCID_CLIENT_SECRET: str | None = None
+    ORCID_REDIRECT_URI: str = "https://aicid.net/manage/orcid/callback"
+
 
 settings = Settings()

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -15,6 +15,8 @@ class User(Base):
     hashed_password: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     full_name: Mapped[str] = mapped_column(String(255), nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    orcid_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    orcid_verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, server_default="0")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     agents = relationship("Agent", back_populates="owner", cascade="all, delete-orphan")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -129,9 +129,9 @@ def _render_login_page(
     status_code: int = 200,
 ) -> HTMLResponse:
     return templates.TemplateResponse(
+        request,
         "auth_login.html",
         {
-            "request": request,
             "next_path": next_path,
             "message": message,
             "error": error,

--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -47,9 +47,9 @@ async def manage_dashboard(
     result = await db.execute(select(Agent).where(Agent.owner_id == user.id).order_by(Agent.created_at.desc()))
     agents = result.scalars().all()
     return templates.TemplateResponse(
+        request,
         "manage.html",
         {
-            "request": request,
             "user": user,
             "agents": agents,
             "updated": updated,
@@ -191,9 +191,9 @@ async def settings_page(
     )
     ssh_keys = result.scalars().all()
     return templates.TemplateResponse(
+        request,
         "settings.html",
         {
-            "request": request,
             "user": user,
             "ssh_keys": ssh_keys,
             "error": error,

--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -1,6 +1,8 @@
-from urllib.parse import quote
+import secrets
+from urllib.parse import quote, urlencode
 
-from fastapi import APIRouter, Depends, Form, Request
+import httpx
+from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -103,10 +105,81 @@ async def update_agent_from_browser(
     return RedirectResponse(url=f"/manage?updated={aicid}", status_code=303)
 
 
+_ORCID_AUTH_URL = "https://orcid.org/oauth/authorize"
+_ORCID_TOKEN_URL = "https://orcid.org/oauth/token"
+
+
+@router.get("/manage/orcid/connect")
+async def orcid_connect(request: Request, db: AsyncSession = Depends(get_db)):
+    user = await _get_browser_user(request, db)
+    if user is None:
+        return _login_redirect("/manage/settings")
+    if not settings.ORCID_CLIENT_ID:
+        return RedirectResponse(url="/manage/settings?error=ORCID+not+configured", status_code=303)
+
+    state = secrets.token_urlsafe(16)
+    params = {
+        "client_id": settings.ORCID_CLIENT_ID,
+        "response_type": "code",
+        "scope": "/authenticate",
+        "redirect_uri": settings.ORCID_REDIRECT_URI,
+        "state": state,
+    }
+    response = RedirectResponse(url=f"{_ORCID_AUTH_URL}?{urlencode(params)}", status_code=302)
+    response.set_cookie("orcid_state", state, httponly=True, samesite="lax", max_age=600)
+    return response
+
+
+@router.get("/manage/orcid/callback")
+async def orcid_callback(
+    request: Request,
+    code: str = Query(...),
+    state: str = Query(""),
+    db: AsyncSession = Depends(get_db),
+):
+    user = await _get_browser_user(request, db)
+    if user is None:
+        return _login_redirect("/manage/settings")
+
+    expected_state = request.cookies.get("orcid_state", "")
+    if not state or state != expected_state:
+        return RedirectResponse(url="/manage/settings?error=Invalid+ORCID+state", status_code=303)
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            _ORCID_TOKEN_URL,
+            data={
+                "client_id": settings.ORCID_CLIENT_ID,
+                "client_secret": settings.ORCID_CLIENT_SECRET,
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": settings.ORCID_REDIRECT_URI,
+            },
+            headers={"Accept": "application/json"},
+        )
+
+    if resp.status_code != 200:
+        return RedirectResponse(url="/manage/settings?error=ORCID+verification+failed", status_code=303)
+
+    data = resp.json()
+    orcid_id = data.get("orcid")
+    if not orcid_id:
+        return RedirectResponse(url="/manage/settings?error=ORCID+verification+failed", status_code=303)
+
+    user.orcid_id = orcid_id
+    user.orcid_verified = True
+    await db.commit()
+
+    response = RedirectResponse(url="/manage/settings?orcid=verified", status_code=303)
+    response.delete_cookie("orcid_state")
+    return response
+
+
 @router.get("/manage/settings", response_class=HTMLResponse)
 async def settings_page(
     request: Request,
     error: str | None = None,
+    orcid: str | None = None,
     db: AsyncSession = Depends(get_db),
 ):
     user = await _get_browser_user(request, db)
@@ -119,7 +192,14 @@ async def settings_page(
     ssh_keys = result.scalars().all()
     return templates.TemplateResponse(
         "settings.html",
-        {"request": request, "user": user, "ssh_keys": ssh_keys, "error": error},
+        {
+            "request": request,
+            "user": user,
+            "ssh_keys": ssh_keys,
+            "error": error,
+            "orcid_verified": orcid == "verified",
+            "orcid_configured": bool(settings.ORCID_CLIENT_ID),
+        },
     )
 
 

--- a/app/routers/oauth.py
+++ b/app/routers/oauth.py
@@ -101,9 +101,9 @@ async def authorize_page(
         raise HTTPException(status_code=400, detail="redirect_uri not allowed")
 
     return templates.TemplateResponse(
+        request,
         "oauth_authorize.html",
         {
-            "request": request,
             "client": client,
             "redirect_uri": redirect_uri,
             "scope": scope,

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -46,6 +46,8 @@ async def public_profile(request: Request, aicid: str, db: AsyncSession = Depend
         await db.execute(select(Funding).where(Funding.agent_id == agent.id))
     ).scalars().all()
 
+    owner = (await db.execute(select(User).where(User.id == agent.owner_id))).scalar_one_or_none()
+
     return templates.TemplateResponse(
         "profile.html",
         {
@@ -54,6 +56,7 @@ async def public_profile(request: Request, aicid: str, db: AsyncSession = Depend
             "works": works,
             "employments": employments,
             "fundings": fundings,
+            "orcid_verified": owner is not None and owner.orcid_verified,
         },
     )
 

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -21,9 +21,23 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 _SKILL_DOC_PATH = _PROJECT_ROOT / "docs" / "SKILL.md"
 
 
+def _normalized_name(value: str | None) -> str:
+    return " ".join((value or "").split()).casefold()
+
+
+def _verified_operator_orcid_url(agent: Agent, owner: User | None) -> str | None:
+    if owner is None or not owner.orcid_verified or not owner.orcid_id:
+        return None
+    if not _normalized_name(agent.human_operator):
+        return None
+    if _normalized_name(agent.human_operator) != _normalized_name(owner.full_name):
+        return None
+    return f"https://orcid.org/{owner.orcid_id}"
+
+
 @router.get("/", response_class=HTMLResponse)
 async def home(request: Request):
-    return templates.TemplateResponse("home.html", {"request": request})
+    return templates.TemplateResponse(request, "home.html", {})
 
 
 @router.get("/SKILL.md", response_class=FileResponse)
@@ -48,15 +62,18 @@ async def public_profile(request: Request, aicid: str, db: AsyncSession = Depend
 
     owner = (await db.execute(select(User).where(User.id == agent.owner_id))).scalar_one_or_none()
 
+    verified_operator_orcid_url = _verified_operator_orcid_url(agent, owner)
+
     return templates.TemplateResponse(
+        request,
         "profile.html",
         {
-            "request": request,
             "agent": agent,
             "works": works,
             "employments": employments,
             "fundings": fundings,
-            "orcid_verified": owner is not None and owner.orcid_verified,
+            "orcid_verified": verified_operator_orcid_url is not None,
+            "operator_orcid_url": verified_operator_orcid_url or agent.operator_orcid,
         },
     )
 
@@ -135,7 +152,7 @@ async def _unique_aicid(db: AsyncSession) -> str:
 
 @router.get("/register", response_class=HTMLResponse)
 async def register_form(request: Request):
-    return templates.TemplateResponse("register.html", {"request": request, "error": None, "values": {}})
+    return templates.TemplateResponse(request, "register.html", {"error": None, "values": {}})
 
 
 @router.post("/register", response_class=HTMLResponse)
@@ -160,8 +177,9 @@ async def register_submit(
 
     if not human_operator or not human_operator.strip():
         return templates.TemplateResponse(
+            request,
             "register.html",
-            {"request": request, "error": "Operator name is required.", "values": values},
+            {"error": "Operator name is required.", "values": values},
             status_code=422,
         )
 
@@ -196,7 +214,7 @@ async def register_submit(
 
 @router.get("/docs", response_class=HTMLResponse)
 async def docs_page(request: Request):
-    return templates.TemplateResponse("docs.html", {"request": request})
+    return templates.TemplateResponse(request, "docs.html", {})
 
 
 @router.get("/search-page", response_class=HTMLResponse)
@@ -234,5 +252,5 @@ async def search_page(
         latest_agents = result.scalars().all()
 
     return templates.TemplateResponse(
-        "search.html", {"request": request, "q": q or "", "agents": agents, "latest_agents": latest_agents}
+        request, "search.html", {"q": q or "", "agents": agents, "latest_agents": latest_agents}
     )

--- a/migrations/versions/006_add_orcid_verified.py
+++ b/migrations/versions/006_add_orcid_verified.py
@@ -1,0 +1,29 @@
+"""add orcid_id and orcid_verified to users
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("orcid_id", sa.String(64), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column("orcid_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "orcid_verified")
+    op.drop_column("users", "orcid_id")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.6
+starlette==0.41.3
 uvicorn[standard]==0.34.0
 sqlalchemy==2.0.36
 greenlet==3.1.1

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -221,6 +221,7 @@ main { flex: 1; }
 .badge-operator { background: #f0e8ff; color: #5a1a8a; }
 .badge-limited { background: #fff0cc; color: #8a5c00; }
 .badge-work-type { background: #d0e8f8; color: #005cb1; margin-right: 0.4rem; }
+.badge-orcid-verified { background: #a6ce39; color: #2d4a00; font-size: 0.85rem; padding: 0.25rem 0.7rem; text-decoration: none; }
 
 /* Search */
 .search-form { display: flex; gap: 0.75rem; margin: 2rem 0 1.5rem; flex-wrap: wrap; }

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -33,13 +33,13 @@
       <span class="agent-name">{{ agent.name }}</span>
       {% if agent.human_operator %}
       <span class="agent-operator">operated by
-        {% if agent.operator_orcid %}
-          <a href="{{ agent.operator_orcid }}" target="_blank" rel="noopener" class="badge badge-operator">{{ agent.human_operator }}</a>
+        {% if operator_orcid_url %}
+          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener" class="badge badge-operator">{{ agent.human_operator }}</a>
         {% else %}
           <span class="badge badge-operator">{{ agent.human_operator }}</span>
         {% endif %}
         {% if orcid_verified %}
-          <a href="https://orcid.org" target="_blank" rel="noopener" class="badge badge-orcid-verified" title="ORCID identity verified">
+          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener" class="badge badge-orcid-verified" title="ORCID identity verified">
             <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="16" height="16" style="vertical-align:middle;margin-right:3px">ORCID Verified
           </a>
         {% endif %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -38,6 +38,11 @@
         {% else %}
           <span class="badge badge-operator">{{ agent.human_operator }}</span>
         {% endif %}
+        {% if orcid_verified %}
+          <a href="https://orcid.org" target="_blank" rel="noopener" class="badge badge-orcid-verified" title="ORCID identity verified">
+            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="16" height="16" style="vertical-align:middle;margin-right:3px">ORCID Verified
+          </a>
+        {% endif %}
       </span>
       {% endif %}
     </h1>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -87,6 +87,25 @@
     </details>
   </section>
 
+  <section class="manage-card" style="margin-bottom:2rem">
+    <div class="manage-card-header">
+      <h2>ORCID Identity</h2>
+    </div>
+    {% if user.orcid_verified %}
+    <p style="margin:0 0 1rem">
+      <strong style="color:#a6ce39">&#10003; ORCID Verified</strong> — your account is linked to ORCID iD
+      <a href="https://orcid.org/{{ user.orcid_id }}" target="_blank" rel="noopener">{{ user.orcid_id }}</a>.
+    </p>
+    {% elif orcid_verified %}
+    <p style="margin:0 0 1rem;color:#2e7d32"><strong>&#10003; ORCID successfully verified!</strong> Your profile will now show the ORCID Verified badge.</p>
+    {% elif orcid_configured %}
+    <p style="margin:0 0 1rem">Connect your ORCID account to display a verified badge on your agent profiles.</p>
+    <a href="/manage/orcid/connect" class="btn btn-primary">Connect ORCID</a>
+    {% else %}
+    <p style="margin:0;color:#666">ORCID integration is not configured on this server.</p>
+    {% endif %}
+  </section>
+
   <section class="manage-card">
     <div class="manage-card-header">
       <h2>Using SSH key authentication</h2>

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,5 +1,8 @@
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.user import User
 
 
 @pytest.mark.asyncio
@@ -28,3 +31,62 @@ async def test_favicon_ico_is_served(client: AsyncClient):
         "image/x-icon",
     }
     assert resp.content
+
+
+@pytest.mark.asyncio
+async def test_public_profile_shows_orcid_verified_badge_for_verified_operator(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "VerifiedBot",
+            "human_operator": "Test User",
+            "operator_orcid": "https://orcid.org/0000-0000-0000-0000",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    user = (await db_session.execute(select(User).where(User.email == "test@example.com"))).scalar_one()
+    user.full_name = "Test User"
+    user.orcid_id = "0000-0002-1825-0097"
+    user.orcid_verified = True
+    await db_session.commit()
+
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert "ORCID Verified" in resp.text
+    assert 'href="https://orcid.org/0000-0002-1825-0097"' in resp.text
+    assert 'href="https://orcid.org/0000-0000-0000-0000"' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_public_profile_hides_orcid_verified_badge_for_different_operator(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "MismatchBot",
+            "human_operator": "Someone Else",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    user = (await db_session.execute(select(User).where(User.email == "test@example.com"))).scalar_one()
+    user.full_name = "Test User"
+    user.orcid_id = "0000-0002-1825-0097"
+    user.orcid_verified = True
+    await db_session.commit()
+
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert "ORCID Verified" not in resp.text


### PR DESCRIPTION
Closes #36

## Changes

- `User` model: new `orcid_id` (String) and `orcid_verified` (Bool, default False) columns
- `Config`: `ORCID_CLIENT_ID`, `ORCID_CLIENT_SECRET`, `ORCID_REDIRECT_URI` env vars
- `GET /manage/orcid/connect` — redirects authenticated user to ORCID OAuth
- `GET /manage/orcid/callback` — exchanges code, stores `orcid_id`, sets `orcid_verified=True`; uses a short-lived cookie for CSRF state check
- Settings page: ORCID section showing current status (verified / connect button / not configured)
- Public profile page: prominent green "ORCID Verified" badge next to operator name when owner is verified
- Migration `006`: `ALTER TABLE users ADD COLUMN orcid_id, orcid_verified`

## Configuration required

Set these env vars on the server to enable the ORCID OAuth flow:
```
ORCID_CLIENT_ID=...
ORCID_CLIENT_SECRET=...
ORCID_REDIRECT_URI=https://aicid.net/manage/orcid/callback
```

Register the redirect URI in the ORCID developer tools for your client.