### PR TITLE
Infer operator ORCID from verified account

### DIFF
--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -63,7 +63,6 @@ async def update_agent_from_browser(
     aicid: str,
     name: str = Form(...),
     human_operator: str = Form(...),
-    operator_orcid: str = Form(""),
     agent_harness: str = Form(""),
     agent_type: str = Form("autonomous_agent"),
     base_model: str = Form(""),
@@ -88,7 +87,6 @@ async def update_agent_from_browser(
 
     agent.name = name.strip()
     agent.human_operator = human_operator.strip()
-    agent.operator_orcid = operator_orcid.strip() or None
     agent.agent_harness = agent_harness.strip() or None
     agent.agent_type = agent_type.strip() or "autonomous_agent"
     agent.base_model = base_model.strip() or None

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -73,7 +73,7 @@ async def public_profile(request: Request, aicid: str, db: AsyncSession = Depend
             "employments": employments,
             "fundings": fundings,
             "orcid_verified": verified_operator_orcid_url is not None,
-            "operator_orcid_url": verified_operator_orcid_url or agent.operator_orcid,
+            "operator_orcid_url": verified_operator_orcid_url,
         },
     )
 

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, field_validator
 class AgentCreate(BaseModel):
     name: str
     human_operator: str
-    operator_orcid: Optional[str] = None
 
     @field_validator("human_operator")
     @classmethod
@@ -31,7 +30,6 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     human_operator: Optional[str] = None
-    operator_orcid: Optional[str] = None
     agent_harness: Optional[str] = None
     agent_type: Optional[str] = None
     base_model: Optional[str] = None

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -39,10 +39,6 @@
             <input id="human-{{ agent.aicid }}" name="human_operator" value="{{ agent.human_operator or '' }}" required>
           </div>
           <div class="form-group">
-            <label for="orcid-{{ agent.aicid }}">Operator ORCID</label>
-            <input id="orcid-{{ agent.aicid }}" name="operator_orcid" value="{{ agent.operator_orcid or '' }}" placeholder="https://orcid.org/0000-0000-0000-0000">
-          </div>
-          <div class="form-group">
             <label for="harness-{{ agent.aicid }}">Agent Harness</label>
             <input id="harness-{{ agent.aicid }}" name="agent_harness" value="{{ agent.agent_harness or '' }}">
           </div>
@@ -87,6 +83,10 @@
             <input id="paper-{{ agent.aicid }}" name="paper_url" value="{{ agent.paper_url or '' }}">
           </div>
         </div>
+
+        <p style="margin:0.75rem 0 0;color:#666;font-size:0.9rem">
+          Operator ORCID is derived from the verified ORCID connected in account settings.
+        </p>
 
         <div class="manage-card-actions">
           <button type="submit" class="btn btn-primary">Save Changes</button>

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -48,6 +48,9 @@ async def test_browser_verify_link_sets_session_cookie_and_allows_manage(client:
     assert manage_resp.status_code == 200
     assert aicid.encode() in manage_resp.content
     assert b"CookieBot" in manage_resp.content
+    assert b'name="operator_orcid"' not in manage_resp.content
+    assert b'id="orcid-' not in manage_resp.content
+    assert b"derived from the verified ORCID connected in account settings" in manage_resp.content
 
 
 @pytest.mark.asyncio

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -44,7 +44,6 @@ async def test_public_profile_shows_orcid_verified_badge_for_verified_operator(
         json={
             "name": "VerifiedBot",
             "human_operator": "Test User",
-            "operator_orcid": "https://orcid.org/0000-0000-0000-0000",
             "visibility": "public",
         },
         headers=auth_headers,
@@ -90,3 +89,26 @@ async def test_public_profile_hides_orcid_verified_badge_for_different_operator(
     resp = await client.get(f"/agents/{aicid}")
     assert resp.status_code == 200
     assert "ORCID Verified" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_public_profile_does_not_link_unverified_manual_operator_orcid(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "ManualOrcidBot",
+            "human_operator": "Test User",
+            "operator_orcid": "https://orcid.org/0000-0000-0000-0000",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert "ORCID Verified" not in resp.text
+    assert 'href="https://orcid.org/0000-0000-0000-0000"' not in resp.text


### PR DESCRIPTION
## Summary
- remove manual operator ORCID editing from the manage UI and browser update flow
- stop using agent-stored operator ORCID values on public profiles
- derive public operator ORCID links only from the verified ORCID connected in account settings
- add regressions covering the hidden form field and the absence of unverified/manual ORCID links

## Testing
- . .venv-ci/bin/activate && pytest tests/test_manage.py tests/test_public.py -q