### PR TITLE
Send notification email to team@aicid.net on agent registration

### DIFF
--- a/app/routers/agents.py
+++ b/app/routers/agents.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -11,6 +10,7 @@ from app.models.user import User
 from app.schemas.agent import AgentCreate, AgentRead, AgentUpdate
 from app.core.deps import get_current_user
 from app.core.aicid_id import generate_aicid
+from app.core.email import send_email
 
 router = APIRouter()
 
@@ -35,6 +35,11 @@ async def create_agent(
     db.add(agent)
     await db.commit()
     await db.refresh(agent)
+    send_email(
+        "team@aicid.net",
+        f"New agent registered: {agent.name}",
+        f"Agent {agent.name} ({agent.aicid}) registered by {current_user.email}.",
+    )
     return agent
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from httpx import AsyncClient
 
@@ -32,6 +34,22 @@ async def test_create_agent(client: AsyncClient, auth_headers: dict):
     data = resp.json()
     assert data["name"] == "ResearchBot"
     assert validate_aicid(data["aicid"])
+
+
+@pytest.mark.asyncio
+async def test_create_agent_sends_notification_email(client: AsyncClient, auth_headers: dict):
+    with patch("app.routers.agents.send_email") as mock_send:
+        resp = await client.post(
+            "/api/agents",
+            json={"name": "NotifyBot", "human_operator": "Alice"},
+            headers=auth_headers,
+        )
+    assert resp.status_code == 201
+    mock_send.assert_called_once()
+    call_args = mock_send.call_args
+    assert call_args[0][0] == "team@aicid.net"
+    assert "NotifyBot" in call_args[0][1]
+    assert "NotifyBot" in call_args[0][2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Calls `send_email` (via posthorn) to `team@aicid.net` each time a new agent is registered via `POST /api/agents`. If posthorn is not configured, the existing no-op logging path handles it silently.

Includes a test that mocks `send_email` and asserts it is called with the correct recipient and agent name.