### PR TITLE
feat: add agent-level contact metadata (closes #40)

### DIFF
--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -29,6 +29,11 @@ class Agent(Base):
     website_url: Mapped[Optional[str]] = mapped_column(String(500))
     github_url: Mapped[Optional[str]] = mapped_column(String(500))
     paper_url: Mapped[Optional[str]] = mapped_column(String(500))
+    agent_email: Mapped[Optional[str]] = mapped_column(String(255))
+    agent_telegram: Mapped[Optional[str]] = mapped_column(String(255))
+    agent_discord: Mapped[Optional[str]] = mapped_column(String(255))
+    agent_twitter: Mapped[Optional[str]] = mapped_column(String(255))
+    agent_url: Mapped[Optional[str]] = mapped_column(String(500))
     visibility: Mapped[str] = mapped_column(String(20), default="public")  # public | limited | private
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(

--- a/app/routers/manage.py
+++ b/app/routers/manage.py
@@ -73,6 +73,11 @@ async def update_agent_from_browser(
     website_url: str = Form(""),
     github_url: str = Form(""),
     paper_url: str = Form(""),
+    agent_email: str = Form(""),
+    agent_telegram: str = Form(""),
+    agent_discord: str = Form(""),
+    agent_twitter: str = Form(""),
+    agent_url: str = Form(""),
     visibility: str = Form("public"),
     db: AsyncSession = Depends(get_db),
 ):
@@ -97,6 +102,11 @@ async def update_agent_from_browser(
     agent.website_url = website_url.strip() or None
     agent.github_url = github_url.strip() or None
     agent.paper_url = paper_url.strip() or None
+    agent.agent_email = agent_email.strip() or None
+    agent.agent_telegram = agent_telegram.strip() or None
+    agent.agent_discord = agent_discord.strip() or None
+    agent.agent_twitter = agent_twitter.strip() or None
+    agent.agent_url = agent_url.strip() or None
     agent.visibility = visibility.strip() or "public"
 
     await db.commit()

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -106,6 +106,11 @@ async def public_profile_json(aicid: str, db: AsyncSession = Depends(get_db)):
         "website_url": agent.website_url,
         "github_url": agent.github_url,
         "paper_url": agent.paper_url,
+        "agent_email": agent.agent_email,
+        "agent_telegram": agent.agent_telegram,
+        "agent_discord": agent.agent_discord,
+        "agent_twitter": agent.agent_twitter,
+        "agent_url": agent.agent_url,
         "visibility": agent.visibility,
         "created_at": agent.created_at.isoformat(),
         "works": [

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
@@ -24,6 +24,11 @@ class AgentCreate(BaseModel):
     website_url: Optional[str] = None
     github_url: Optional[str] = None
     paper_url: Optional[str] = None
+    agent_email: Optional[str] = None
+    agent_telegram: Optional[str] = None
+    agent_discord: Optional[str] = None
+    agent_twitter: Optional[str] = None
+    agent_url: Optional[str] = None
     visibility: str = "public"
 
 
@@ -40,6 +45,11 @@ class AgentUpdate(BaseModel):
     website_url: Optional[str] = None
     github_url: Optional[str] = None
     paper_url: Optional[str] = None
+    agent_email: Optional[str] = None
+    agent_telegram: Optional[str] = None
+    agent_discord: Optional[str] = None
+    agent_twitter: Optional[str] = None
+    agent_url: Optional[str] = None
     visibility: Optional[str] = None
 
 
@@ -60,6 +70,11 @@ class AgentRead(BaseModel):
     website_url: Optional[str]
     github_url: Optional[str]
     paper_url: Optional[str]
+    agent_email: Optional[str]
+    agent_telegram: Optional[str]
+    agent_discord: Optional[str]
+    agent_twitter: Optional[str]
+    agent_url: Optional[str]
     visibility: str
     created_at: datetime
     updated_at: datetime

--- a/migrations/versions/007_add_agent_contact_fields.py
+++ b/migrations/versions/007_add_agent_contact_fields.py
@@ -1,0 +1,32 @@
+"""add agent contact fields
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-07-16
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("agent_email", sa.String(255), nullable=True))
+    op.add_column("agents", sa.Column("agent_telegram", sa.String(255), nullable=True))
+    op.add_column("agents", sa.Column("agent_discord", sa.String(255), nullable=True))
+    op.add_column("agents", sa.Column("agent_twitter", sa.String(255), nullable=True))
+    op.add_column("agents", sa.Column("agent_url", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "agent_url")
+    op.drop_column("agents", "agent_twitter")
+    op.drop_column("agents", "agent_discord")
+    op.drop_column("agents", "agent_telegram")
+    op.drop_column("agents", "agent_email")

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
         <a href="/manage">Manage</a>
         <a href="/manage/settings">Settings</a>
         <a href="/docs">Docs</a>
-        <a href="https://github.com/4open-science/aicid-net" target="_blank">GitHub</a>
+        <a href="https://github.com/4open-science/aicid-net" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
     </div>
   </header>
@@ -36,8 +36,8 @@
   <footer class="site-footer">
     <div class="container">
       <p>AICID — Unique identifiers for AI scientists and co-scientists.
-        Inspired by <a href="https://orcid.org" target="_blank">ORCID</a>.
-        <a href="/docs">Docs</a> · <a href="https://aicid.net/SKILL.md" target="_blank">API reference</a> · <a href="https://github.com/4open-science/aicid-net" target="_blank">Source</a>
+        Inspired by <a href="https://orcid.org" target="_blank" rel="noopener noreferrer">ORCID</a>.
+        <a href="/docs">Docs</a> · <a href="https://aicid.net/SKILL.md" target="_blank" rel="noopener noreferrer">API reference</a> · <a href="https://github.com/4open-science/aicid-net" target="_blank" rel="noopener noreferrer">Source</a>
       </p>
     </div>
   </footer>

--- a/templates/docs.html
+++ b/templates/docs.html
@@ -49,7 +49,7 @@
     <!-- ── WEBSITE UI ─────────────────────────────────────────── -->
     <section class="docs-section" id="ui-guide">
       <h2>Using the Website</h2>
-      <p>The web interface at <a href="https://aicid.net/" target="_blank">aicid.net</a> lets you register agents, browse profiles, and search the registry — no programming required.</p>
+      <p>The web interface at <a href="https://aicid.net/" target="_blank" rel="noopener noreferrer">aicid.net</a> lets you register agents, browse profiles, and search the registry — no programming required.</p>
 
       <h3 id="ui-register">1. Register an agent</h3>
       <ol>
@@ -79,7 +79,7 @@
         Every registered agent has a public profile page at
         <code>https://aicid.net/agents/&lt;AICID&gt;</code>.
         Example:
-        <a href="https://aicid.net/agents/AICID-5282-9748-4313-4513" target="_blank">
+        <a href="https://aicid.net/agents/AICID-5282-9748-4313-4513" target="_blank" rel="noopener noreferrer">
           aicid.net/agents/AICID-5282-9748-4313-4513
         </a>.
       </p>

--- a/templates/home.html
+++ b/templates/home.html
@@ -24,7 +24,7 @@
     <div class="feature-card">
       <div class="feature-icon">🔬</div>
       <h3>For AI Co-Scientists</h3>
-      <p>Register autonomous agents and LLM pipelines that contribute to scientific research with a persistent, citable identity. Load the <a href="https://aicid.net/SKILL.md" target="_blank">agent skill</a>.</p>
+      <p>Register autonomous agents and LLM pipelines that contribute to scientific research with a persistent, citable identity. Load the <a href="https://aicid.net/SKILL.md" target="_blank" rel="noopener noreferrer">agent skill</a>.</p>
     </div>
     <div class="feature-card">
       <div class="feature-icon">📄</div>

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -82,6 +82,26 @@
             <label for="paper-{{ agent.aicid }}">Paper URL</label>
             <input id="paper-{{ agent.aicid }}" name="paper_url" value="{{ agent.paper_url or '' }}">
           </div>
+          <div class="form-group">
+            <label for="agent-email-{{ agent.aicid }}">Agent Email</label>
+            <input id="agent-email-{{ agent.aicid }}" name="agent_email" value="{{ agent.agent_email or '' }}">
+          </div>
+          <div class="form-group">
+            <label for="agent-telegram-{{ agent.aicid }}">Agent Telegram</label>
+            <input id="agent-telegram-{{ agent.aicid }}" name="agent_telegram" value="{{ agent.agent_telegram or '' }}">
+          </div>
+          <div class="form-group">
+            <label for="agent-discord-{{ agent.aicid }}">Agent Discord</label>
+            <input id="agent-discord-{{ agent.aicid }}" name="agent_discord" value="{{ agent.agent_discord or '' }}">
+          </div>
+          <div class="form-group">
+            <label for="agent-twitter-{{ agent.aicid }}">Agent Twitter/X</label>
+            <input id="agent-twitter-{{ agent.aicid }}" name="agent_twitter" value="{{ agent.agent_twitter or '' }}">
+          </div>
+          <div class="form-group">
+            <label for="agent-url-{{ agent.aicid }}">Agent Contact URL</label>
+            <input id="agent-url-{{ agent.aicid }}" name="agent_url" value="{{ agent.agent_url or '' }}">
+          </div>
         </div>
 
         <p style="margin:0.75rem 0 0;color:#666;font-size:0.9rem">

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -26,7 +26,7 @@
             <h2>{{ agent.name }}</h2>
             <p class="manage-card-sub">{{ agent.aicid }}</p>
           </div>
-          <a href="/agents/{{ agent.aicid }}" target="_blank">View public profile</a>
+          <a href="/agents/{{ agent.aicid }}" target="_blank" rel="noopener noreferrer">View public profile</a>
         </div>
 
         <div class="manage-fields">
@@ -84,23 +84,23 @@
           </div>
           <div class="form-group">
             <label for="agent-email-{{ agent.aicid }}">Agent Email</label>
-            <input id="agent-email-{{ agent.aicid }}" name="agent_email" value="{{ agent.agent_email or '' }}">
+            <input id="agent-email-{{ agent.aicid }}" name="agent_email" type="email" maxlength="255" value="{{ agent.agent_email or '' }}">
           </div>
           <div class="form-group">
             <label for="agent-telegram-{{ agent.aicid }}">Agent Telegram</label>
-            <input id="agent-telegram-{{ agent.aicid }}" name="agent_telegram" value="{{ agent.agent_telegram or '' }}">
+            <input id="agent-telegram-{{ agent.aicid }}" name="agent_telegram" maxlength="255" value="{{ agent.agent_telegram or '' }}">
           </div>
           <div class="form-group">
-            <label for="agent-discord-{{ agent.aicid }}">Agent Discord</label>
-            <input id="agent-discord-{{ agent.aicid }}" name="agent_discord" value="{{ agent.agent_discord or '' }}">
+            <label for="agent-discord-{{ agent.aicid }}">Agent Discord Handle</label>
+            <input id="agent-discord-{{ agent.aicid }}" name="agent_discord" maxlength="255" value="{{ agent.agent_discord or '' }}">
           </div>
           <div class="form-group">
             <label for="agent-twitter-{{ agent.aicid }}">Agent Twitter/X</label>
-            <input id="agent-twitter-{{ agent.aicid }}" name="agent_twitter" value="{{ agent.agent_twitter or '' }}">
+            <input id="agent-twitter-{{ agent.aicid }}" name="agent_twitter" maxlength="255" value="{{ agent.agent_twitter or '' }}">
           </div>
           <div class="form-group">
             <label for="agent-url-{{ agent.aicid }}">Agent Contact URL</label>
-            <input id="agent-url-{{ agent.aicid }}" name="agent_url" value="{{ agent.agent_url or '' }}">
+            <input id="agent-url-{{ agent.aicid }}" name="agent_url" type="url" maxlength="500" value="{{ agent.agent_url or '' }}">
           </div>
         </div>
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -26,6 +26,16 @@
       <a href="/agents/{{ agent.aicid }}/json">{ } JSON</a>
       <a href="/auth/login">✉️ Manage by email</a>
     </div>
+    {% if agent.agent_email or agent.agent_telegram or agent.agent_discord or agent.agent_twitter or agent.agent_url %}
+    <div class="agent-contact">
+      <h3>Contact the agent</h3>
+      {% if agent.agent_email %}<a href="mailto:{{ agent.agent_email }}">✉️ {{ agent.agent_email }}</a>{% endif %}
+      {% if agent.agent_telegram %}<a href="https://t.me/{{ agent.agent_telegram | replace('@', '') }}" target="_blank">✈️ Telegram: {{ agent.agent_telegram }}</a>{% endif %}
+      {% if agent.agent_discord %}<span>💬 Discord: {{ agent.agent_discord }}</span>{% endif %}
+      {% if agent.agent_twitter %}<a href="https://twitter.com/{{ agent.agent_twitter | replace('@', '') }}" target="_blank">🐦 {{ agent.agent_twitter }}</a>{% endif %}
+      {% if agent.agent_url %}<a href="{{ agent.agent_url }}" target="_blank">🔗 Contact / Chat</a>{% endif %}
+    </div>
+    {% endif %}
   </aside>
 
   <div class="profile-main">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -20,9 +20,9 @@
       <p class="agent-model">⚙️ Base: {{ agent.base_model }}{% if agent.version %} {{ agent.version }}{% endif %}</p>
     {% endif %}
     <div class="agent-links">
-      {% if agent.website_url %}<a href="{{ agent.website_url }}" target="_blank">🌐 Website</a>{% endif %}
-      {% if agent.github_url %}<a href="{{ agent.github_url }}" target="_blank">💻 GitHub</a>{% endif %}
-      {% if agent.paper_url %}<a href="{{ agent.paper_url }}" target="_blank">📑 Paper</a>{% endif %}
+      {% if agent.website_url %}<a href="{{ agent.website_url }}" target="_blank" rel="noopener noreferrer">🌐 Website</a>{% endif %}
+      {% if agent.github_url %}<a href="{{ agent.github_url }}" target="_blank" rel="noopener noreferrer">💻 GitHub</a>{% endif %}
+      {% if agent.paper_url %}<a href="{{ agent.paper_url }}" target="_blank" rel="noopener noreferrer">📑 Paper</a>{% endif %}
       <a href="/agents/{{ agent.aicid }}/json">{ } JSON</a>
       <a href="/auth/login">✉️ Manage by email</a>
     </div>
@@ -30,10 +30,10 @@
     <div class="agent-contact">
       <h3>Contact the agent</h3>
       {% if agent.agent_email %}<a href="mailto:{{ agent.agent_email }}">✉️ {{ agent.agent_email }}</a>{% endif %}
-      {% if agent.agent_telegram %}<a href="https://t.me/{{ agent.agent_telegram | replace('@', '') }}" target="_blank">✈️ Telegram: {{ agent.agent_telegram }}</a>{% endif %}
-      {% if agent.agent_discord %}<span>💬 Discord: {{ agent.agent_discord }}</span>{% endif %}
-      {% if agent.agent_twitter %}<a href="https://twitter.com/{{ agent.agent_twitter | replace('@', '') }}" target="_blank">🐦 {{ agent.agent_twitter }}</a>{% endif %}
-      {% if agent.agent_url %}<a href="{{ agent.agent_url }}" target="_blank">🔗 Contact / Chat</a>{% endif %}
+      {% if agent.agent_telegram %}<a href="https://t.me/{{ agent.agent_telegram | replace('@', '') }}" target="_blank" rel="noopener noreferrer">✈️ Telegram: {{ agent.agent_telegram }}</a>{% endif %}
+      {% if agent.agent_discord %}<span>💬 Discord handle: {{ agent.agent_discord }}</span>{% endif %}
+      {% if agent.agent_twitter %}<a href="https://twitter.com/{{ agent.agent_twitter | replace('@', '') }}" target="_blank" rel="noopener noreferrer">🐦 {{ agent.agent_twitter }}</a>{% endif %}
+      {% if agent.agent_url %}<span>🔗 Contact / Chat: {{ agent.agent_url }}</span>{% endif %}
     </div>
     {% endif %}
   </aside>
@@ -44,12 +44,12 @@
       {% if agent.human_operator %}
       <span class="agent-operator">operated by
         {% if operator_orcid_url %}
-          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener" class="badge badge-operator">{{ agent.human_operator }}</a>
+          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener noreferrer" class="badge badge-operator">{{ agent.human_operator }}</a>
         {% else %}
           <span class="badge badge-operator">{{ agent.human_operator }}</span>
         {% endif %}
         {% if orcid_verified %}
-          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener" class="badge badge-orcid-verified" title="ORCID identity verified">
+          <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener noreferrer" class="badge badge-orcid-verified" title="ORCID identity verified">
             <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="16" height="16" style="vertical-align:middle;margin-right:3px">ORCID Verified
           </a>
         {% endif %}
@@ -100,10 +100,10 @@
         <li class="record-item">
           <span class="badge badge-work-type">{{ w.work_type }}</span>
           <div class="record-title">
-            {% if w.url %}<a href="{{ w.url }}" target="_blank">{{ w.title }}</a>{% else %}{{ w.title }}{% endif %}
+            {% if w.url %}<a href="{{ w.url }}" target="_blank" rel="noopener noreferrer">{{ w.title }}</a>{% else %}{{ w.title }}{% endif %}
           </div>
           {% if w.journal %}<div class="record-sub">{{ w.journal }}</div>{% endif %}
-          {% if w.doi %}<div class="record-sub">DOI: <a href="https://doi.org/{{ w.doi }}" target="_blank">{{ w.doi }}</a></div>{% endif %}
+          {% if w.doi %}<div class="record-sub">DOI: <a href="https://doi.org/{{ w.doi }}" target="_blank" rel="noopener noreferrer">{{ w.doi }}</a></div>{% endif %}
           {% if w.published_date %}<div class="record-dates">{{ w.published_date }}</div>{% endif %}
         </li>
         {% endfor %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -94,7 +94,7 @@
     {% if user.orcid_verified %}
     <p style="margin:0 0 1rem">
       <strong style="color:#a6ce39">&#10003; ORCID Verified</strong> — your account is linked to ORCID iD
-      <a href="https://orcid.org/{{ user.orcid_id }}" target="_blank" rel="noopener">{{ user.orcid_id }}</a>.
+      <a href="https://orcid.org/{{ user.orcid_id }}" target="_blank" rel="noopener noreferrer">{{ user.orcid_id }}</a>.
     </p>
     {% elif orcid_verified %}
     <p style="margin:0 0 1rem;color:#2e7d32"><strong>&#10003; ORCID successfully verified!</strong> Your profile will now show the ORCID Verified badge.</p>
@@ -118,7 +118,7 @@ Date: &lt;RFC7231_DATE&gt;</code></pre>
     <pre style="background:#f6f8fa;padding:1rem;border-radius:6px;overflow-x:auto;font-size:0.8rem"><code>Content-Digest: sha-256=:&lt;BASE64_SHA256_OF_BODY&gt;:</code></pre>
     <p style="font-size:0.9rem">
       The signature covers the <strong>RFC 9421 signature base</strong> constructed from the listed components.
-      See <a href="/docs">the docs</a> or <a href="https://www.rfc-editor.org/rfc/rfc9421" target="_blank">RFC 9421</a> for details.
+      See <a href="/docs">the docs</a> or <a href="https://www.rfc-editor.org/rfc/rfc9421" target="_blank" rel="noopener noreferrer">RFC 9421</a> for details.
     </p>
   </section>
 </div>

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -160,6 +160,39 @@ async def test_public_profile_json(client: AsyncClient, auth_headers: dict):
 
 
 @pytest.mark.asyncio
+async def test_public_profile_renders_agent_contact_metadata(client: AsyncClient, auth_headers: dict):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "ContactBot",
+            "human_operator": "Alice",
+            "visibility": "public",
+            "agent_email": "contactbot@example.com",
+            "agent_telegram": "@contactbot",
+            "agent_discord": "contactbot",
+            "agent_twitter": "@contactbot",
+            "agent_url": "https://example.com/chat",
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    aicid = create_resp.json()["aicid"]
+
+    profile_resp = await client.get(f"/agents/{aicid}")
+    assert profile_resp.status_code == 200
+    assert 'href="mailto:contactbot@example.com"' in profile_resp.text
+    assert 'href="https://t.me/contactbot" target="_blank" rel="noopener noreferrer"' in profile_resp.text
+    assert "Discord handle: contactbot" in profile_resp.text
+    assert 'href="https://twitter.com/contactbot" target="_blank" rel="noopener noreferrer"' in profile_resp.text
+    assert "Contact / Chat: https://example.com/chat" in profile_resp.text
+    assert 'href="https://example.com/chat"' not in profile_resp.text
+
+    json_resp = await client.get(f"/agents/{aicid}/json")
+    assert json_resp.status_code == 200
+    assert json_resp.json()["agent_url"] == "https://example.com/chat"
+
+
+@pytest.mark.asyncio
 async def test_public_profile_shows_agent_type_and_operator(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -51,6 +51,9 @@ async def test_browser_verify_link_sets_session_cookie_and_allows_manage(client:
     assert b'name="operator_orcid"' not in manage_resp.content
     assert b'id="orcid-' not in manage_resp.content
     assert b"derived from the verified ORCID connected in account settings" in manage_resp.content
+    assert f'id="agent-email-{aicid}" name="agent_email" type="email" maxlength="255"'.encode() in manage_resp.content
+    assert f'id="agent-url-{aicid}" name="agent_url" type="url" maxlength="500"'.encode() in manage_resp.content
+    assert f'for="agent-discord-{aicid}">Agent Discord Handle'.encode() in manage_resp.content
 
 
 @pytest.mark.asyncio
@@ -94,6 +97,11 @@ async def test_browser_manage_updates_public_registered_agent(client: AsyncClien
             "website_url": "https://example.com",
             "github_url": "https://github.com/example/repo",
             "paper_url": "https://example.com/paper",
+            "agent_email": "editbot@example.com",
+            "agent_telegram": "editbot",
+            "agent_discord": "editbot",
+            "agent_twitter": "@editbot",
+            "agent_url": "https://example.com/chat",
             "visibility": "limited",
         },
         follow_redirects=False,
@@ -110,3 +118,8 @@ async def test_browser_manage_updates_public_registered_agent(client: AsyncClien
     assert data["organization"] == "Open Science Lab"
     assert data["description"] == "Updated from the browser."
     assert data["visibility"] == "limited"
+    assert data["agent_email"] == "editbot@example.com"
+    assert data["agent_telegram"] == "editbot"
+    assert data["agent_discord"] == "editbot"
+    assert data["agent_twitter"] == "@editbot"
+    assert data["agent_url"] == "https://example.com/chat"


### PR DESCRIPTION
## Summary

- Add 5 optional contact fields to the `Agent` model: `agent_email`, `agent_telegram`, `agent_discord`, `agent_twitter`, `agent_url`
- Migration `007_add_agent_contact_fields` adds the columns to the DB
- `AgentCreate`, `AgentUpdate`, `AgentRead` schemas updated accordingly
- Manage dashboard (`/manage`) exposes form inputs for all 5 fields
- Public profile page renders a "Contact the agent" sidebar section when any field is set
- JSON endpoint (`/agents/{aicid}/json`) includes the new fields

Closes #40