### PR TITLE
Allow operator ORCID updates via API

### DIFF
--- a/app/core/orcid.py
+++ b/app/core/orcid.py
@@ -1,0 +1,34 @@
+import re
+
+
+_ORCID_PATTERN = re.compile(
+    r"^(?:https?://(?:www\.)?orcid\.org/)?"
+    r"(\d{4})-(\d{4})-(\d{4})-(\d{3}[\dXx])/?$"
+)
+
+
+def normalize_orcid(value: str | None) -> str | None:
+    """Validate an ORCID iD and return its canonical HTTPS URL."""
+    if value is None:
+        return None
+
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    match = _ORCID_PATTERN.fullmatch(candidate)
+    if match is None:
+        raise ValueError("Invalid ORCID iD")
+
+    orcid_id = "-".join(match.groups()).upper()
+    compact = orcid_id.replace("-", "")
+
+    total = 0
+    for digit in compact[:-1]:
+        total = (total + int(digit)) * 2
+    check_value = (12 - total % 11) % 11
+    expected_check = "X" if check_value == 10 else str(check_value)
+    if compact[-1] != expected_check:
+        raise ValueError("Invalid ORCID iD checksum")
+
+    return f"https://orcid.org/{orcid_id}"

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
+
+from app.core.orcid import normalize_orcid
 
 
 class AgentCreate(BaseModel):
@@ -35,6 +37,14 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     human_operator: Optional[str] = None
+    operator_orcid: Optional[str] = Field(
+        default=None,
+        title="Operator ORCID",
+        description=(
+            "Self-declared ORCID metadata. This does not grant ORCID Verified status, "
+            "which requires OAuth verification."
+        ),
+    )
     agent_harness: Optional[str] = None
     agent_type: Optional[str] = None
     base_model: Optional[str] = None
@@ -51,6 +61,11 @@ class AgentUpdate(BaseModel):
     agent_twitter: Optional[str] = None
     agent_url: Optional[str] = None
     visibility: Optional[str] = None
+
+    @field_validator("operator_orcid")
+    @classmethod
+    def normalize_operator_orcid(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_orcid(value)
 
 
 class AgentRead(BaseModel):

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -126,6 +126,12 @@ with urllib.request.urlopen(req) as r:
     print(json.loads(r.read()))
 ```
 
+`operator_orcid` can be updated through this endpoint as self-declared
+metadata. Pass either a bare ORCID iD or an `https://orcid.org/...` URL; AICID
+validates its checksum and stores the canonical HTTPS URL. Set it to `null` to
+remove it. This field does not grant the **ORCID Verified** badge: verification
+still requires the operator to connect ORCID through OAuth in account settings.
+
 ### Replay protection
 
 Requests are rejected if the `created` timestamp in `Signature-Input` is more than 5 minutes old. Always set `created` to the current Unix time and `Date` to the current UTC time.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -107,6 +107,98 @@ async def test_update_agent(client: AsyncClient, auth_headers: dict):
 
 
 @pytest.mark.asyncio
+async def test_update_agent_operator_orcid(client: AsyncClient, auth_headers: dict):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "OrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": "0000-0002-1825-0097"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 200
+    assert update_resp.json()["operator_orcid"] == "https://orcid.org/0000-0002-1825-0097"
+
+    get_resp = await client.get(f"/api/agents/{aicid}", headers=auth_headers)
+    assert get_resp.json()["operator_orcid"] == "https://orcid.org/0000-0002-1825-0097"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_accepts_operator_orcid_with_x_checksum(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "OrcidXBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": "https://orcid.org/0000-0002-1694-233x"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 200
+    assert update_resp.json()["operator_orcid"] == "https://orcid.org/0000-0002-1694-233X"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_rejects_invalid_operator_orcid(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "InvalidOrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": "0000-0000-0000-0000"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_agent_can_clear_operator_orcid(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "ClearOrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+    await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": "https://orcid.org/0000-0002-1825-0097"},
+        headers=auth_headers,
+    )
+
+    clear_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": None},
+        headers=auth_headers,
+    )
+
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["operator_orcid"] is None
+
+
+@pytest.mark.asyncio
 async def test_delete_agent(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -101,14 +101,19 @@ async def test_public_profile_does_not_link_unverified_manual_operator_orcid(
         json={
             "name": "ManualOrcidBot",
             "human_operator": "Test User",
-            "operator_orcid": "https://orcid.org/0000-0000-0000-0000",
             "visibility": "public",
         },
         headers=auth_headers,
     )
     aicid = create_resp.json()["aicid"]
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"operator_orcid": "https://orcid.org/0000-0002-1825-0097"},
+        headers=auth_headers,
+    )
+    assert update_resp.status_code == 200
 
     resp = await client.get(f"/agents/{aicid}")
     assert resp.status_code == 200
     assert "ORCID Verified" not in resp.text
-    assert 'href="https://orcid.org/0000-0000-0000-0000"' not in resp.text
+    assert 'href="https://orcid.org/0000-0002-1825-0097"' not in resp.text


### PR DESCRIPTION
## Summary
- allow owners to update the existing operator_orcid metadata through PATCH /api/agents/{aicid}
- validate ORCID format and ISO 7064 checksum, then store a canonical HTTPS URL
- keep self-declared metadata separate from OAuth-backed ORCID Verified status
- document update and clearing semantics

## Testing
- 46 tests passed
- added coverage for persistence, canonicalization, X checksums, invalid checksums, clearing, and prevention of an unverified public badge/link

No database migration is required because the operator_orcid column already exists.