### PR TITLE
Add settable orcid_unverified field for self-declared ORCID metadata

### DIFF
--- a/app/core/orcid.py
+++ b/app/core/orcid.py
@@ -1,0 +1,34 @@
+import re
+
+
+_ORCID_PATTERN = re.compile(
+    r"^(?:https?://(?:www\.)?orcid\.org/)?"
+    r"(\d{4})-(\d{4})-(\d{4})-(\d{3}[\dXx])/?$"
+)
+
+
+def normalize_orcid(value: str | None) -> str | None:
+    """Validate an ORCID iD and return its canonical HTTPS URL."""
+    if value is None:
+        return None
+
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    match = _ORCID_PATTERN.fullmatch(candidate)
+    if match is None:
+        raise ValueError("Invalid ORCID iD")
+
+    orcid_id = "-".join(match.groups()).upper()
+    compact = orcid_id.replace("-", "")
+
+    total = 0
+    for digit in compact[:-1]:
+        total = (total + int(digit)) * 2
+    check_value = (12 - total % 11) % 11
+    expected_check = "X" if check_value == 10 else str(check_value)
+    if compact[-1] != expected_check:
+        raise ValueError("Invalid ORCID iD checksum")
+
+    return f"https://orcid.org/{orcid_id}"

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -17,6 +17,7 @@ class Agent(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     human_operator: Mapped[Optional[str]] = mapped_column(String(255))
     operator_orcid: Mapped[Optional[str]] = mapped_column(String(500))
+    orcid_unverified: Mapped[Optional[str]] = mapped_column(String(500))
     agent_harness: Mapped[Optional[str]] = mapped_column(String(255))
     agent_type: Mapped[str] = mapped_column(
         String(50), nullable=False, default="autonomous_agent"

--- a/app/routers/public.py
+++ b/app/routers/public.py
@@ -74,6 +74,7 @@ async def public_profile(request: Request, aicid: str, db: AsyncSession = Depend
             "fundings": fundings,
             "orcid_verified": verified_operator_orcid_url is not None,
             "operator_orcid_url": verified_operator_orcid_url,
+            "orcid_unverified": agent.orcid_unverified,
         },
     )
 
@@ -98,6 +99,7 @@ async def public_profile_json(aicid: str, db: AsyncSession = Depends(get_db)):
         "name": agent.name,
         "agent_type": agent.agent_type,
         "human_operator": agent.human_operator,
+        "orcid_unverified": agent.orcid_unverified,
         "base_model": agent.base_model,
         "version": agent.version,
         "organization": agent.organization,

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,7 +1,15 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
+
+from app.core.orcid import normalize_orcid
+
+_ORCID_UNVERIFIED_DESCRIPTION = (
+    "Self-declared ORCID metadata, not verified by ORCID OAuth. This does not "
+    "grant ORCID Verified status or link this agent to an ORCID account; it is "
+    "only displayed as unverified."
+)
 
 
 class AgentCreate(BaseModel):
@@ -14,6 +22,9 @@ class AgentCreate(BaseModel):
         if not v or not v.strip():
             raise ValueError("human_operator is required")
         return v
+    orcid_unverified: Optional[str] = Field(
+        default=None, title="Unverified ORCID", description=_ORCID_UNVERIFIED_DESCRIPTION
+    )
     agent_harness: Optional[str] = None
     agent_type: str = "autonomous_agent"
     base_model: Optional[str] = None
@@ -31,10 +42,18 @@ class AgentCreate(BaseModel):
     agent_url: Optional[str] = None
     visibility: str = "public"
 
+    @field_validator("orcid_unverified")
+    @classmethod
+    def normalize_orcid_unverified(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_orcid(value)
+
 
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     human_operator: Optional[str] = None
+    orcid_unverified: Optional[str] = Field(
+        default=None, title="Unverified ORCID", description=_ORCID_UNVERIFIED_DESCRIPTION
+    )
     agent_harness: Optional[str] = None
     agent_type: Optional[str] = None
     base_model: Optional[str] = None
@@ -52,6 +71,11 @@ class AgentUpdate(BaseModel):
     agent_url: Optional[str] = None
     visibility: Optional[str] = None
 
+    @field_validator("orcid_unverified")
+    @classmethod
+    def normalize_orcid_unverified(cls, value: Optional[str]) -> Optional[str]:
+        return normalize_orcid(value)
+
 
 class AgentRead(BaseModel):
     id: int
@@ -60,6 +84,7 @@ class AgentRead(BaseModel):
     name: str
     human_operator: Optional[str]
     operator_orcid: Optional[str]
+    orcid_unverified: Optional[str]
     agent_harness: Optional[str]
     agent_type: str
     base_model: Optional[str]

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -126,6 +126,14 @@ with urllib.request.urlopen(req) as r:
     print(json.loads(r.read()))
 ```
 
+`orcid_unverified` can be set through `POST /api/agents` or this PATCH endpoint as
+self-declared metadata. Pass either a bare ORCID iD or an
+`https://orcid.org/...` URL; AICID validates its checksum and stores the
+canonical HTTPS URL. Set it to `null` to remove it. This field does not grant
+the **ORCID Verified** badge and is always displayed as unverified: real
+verification still requires the operator to connect ORCID through OAuth in
+account settings, which populates a separate, verified badge instead.
+
 ### Replay protection
 
 Requests are rejected if the `created` timestamp in `Signature-Input` is more than 5 minutes old. Always set `created` to the current Unix time and `Date` to the current UTC time.

--- a/migrations/versions/008_add_orcid_unverified.py
+++ b/migrations/versions/008_add_orcid_unverified.py
@@ -1,0 +1,24 @@
+"""add orcid_unverified to agents
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-07-27
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agents", sa.Column("orcid_unverified", sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "orcid_unverified")

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -222,6 +222,7 @@ main { flex: 1; }
 .badge-limited { background: #fff0cc; color: #8a5c00; }
 .badge-work-type { background: #d0e8f8; color: #005cb1; margin-right: 0.4rem; }
 .badge-orcid-verified { background: #a6ce39; color: #2d4a00; font-size: 0.85rem; padding: 0.25rem 0.7rem; text-decoration: none; }
+.badge-orcid-unverified { background: #e8e8e8; color: #555; font-size: 0.85rem; padding: 0.25rem 0.7rem; text-decoration: none; }
 
 /* Search */
 .search-form { display: flex; gap: 0.75rem; margin: 2rem 0 1.5rem; flex-wrap: wrap; }

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -52,6 +52,10 @@
           <a href="{{ operator_orcid_url }}" target="_blank" rel="noopener noreferrer" class="badge badge-orcid-verified" title="ORCID identity verified">
             <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="16" height="16" style="vertical-align:middle;margin-right:3px">ORCID Verified
           </a>
+        {% elif orcid_unverified %}
+          <a href="{{ orcid_unverified }}" target="_blank" rel="noopener noreferrer" class="badge badge-orcid-unverified" title="Self-declared ORCID iD, not verified by ORCID OAuth">
+            <img src="https://orcid.org/sites/default/files/images/orcid_16x16.png" alt="ORCID" width="16" height="16" style="vertical-align:middle;margin-right:3px">ORCID (unverified)
+          </a>
         {% endif %}
       </span>
       {% endif %}

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -107,6 +107,114 @@ async def test_update_agent(client: AsyncClient, auth_headers: dict):
 
 
 @pytest.mark.asyncio
+async def test_create_agent_with_orcid_unverified(client: AsyncClient, auth_headers: dict):
+    resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "OrcidBot",
+            "human_operator": "Alice",
+            "orcid_unverified": "0000-0002-1825-0097",
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["orcid_unverified"] == "https://orcid.org/0000-0002-1825-0097"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_orcid_unverified(client: AsyncClient, auth_headers: dict):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "OrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"orcid_unverified": "0000-0002-1825-0097"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 200
+    assert update_resp.json()["orcid_unverified"] == "https://orcid.org/0000-0002-1825-0097"
+
+    get_resp = await client.get(f"/api/agents/{aicid}", headers=auth_headers)
+    assert get_resp.json()["orcid_unverified"] == "https://orcid.org/0000-0002-1825-0097"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_accepts_orcid_unverified_with_x_checksum(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "OrcidXBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"orcid_unverified": "https://orcid.org/0000-0002-1694-233x"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 200
+    assert update_resp.json()["orcid_unverified"] == "https://orcid.org/0000-0002-1694-233X"
+
+
+@pytest.mark.asyncio
+async def test_update_agent_rejects_invalid_orcid_unverified(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "InvalidOrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    update_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"orcid_unverified": "0000-0000-0000-0000"},
+        headers=auth_headers,
+    )
+
+    assert update_resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_agent_can_clear_orcid_unverified(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={"name": "ClearOrcidBot", "human_operator": "Alice"},
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+    await client.patch(
+        f"/api/agents/{aicid}",
+        json={"orcid_unverified": "https://orcid.org/0000-0002-1825-0097"},
+        headers=auth_headers,
+    )
+
+    clear_resp = await client.patch(
+        f"/api/agents/{aicid}",
+        json={"orcid_unverified": None},
+        headers=auth_headers,
+    )
+
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["orcid_unverified"] is None
+
+
+@pytest.mark.asyncio
 async def test_delete_agent(client: AsyncClient, auth_headers: dict):
     create_resp = await client.post(
         "/api/agents",

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -112,3 +112,57 @@ async def test_public_profile_does_not_link_unverified_manual_operator_orcid(
     assert resp.status_code == 200
     assert "ORCID Verified" not in resp.text
     assert 'href="https://orcid.org/0000-0000-0000-0000"' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_public_profile_shows_self_declared_orcid_as_unverified(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "SelfDeclaredOrcidBot",
+            "human_operator": "Test User",
+            "orcid_unverified": "0000-0002-1825-0097",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert "ORCID Verified" not in resp.text
+    assert "ORCID (unverified)" in resp.text
+    assert 'href="https://orcid.org/0000-0002-1825-0097"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_public_profile_prefers_verified_badge_over_self_declared_orcid(
+    client: AsyncClient,
+    auth_headers: dict,
+    db_session,
+):
+    create_resp = await client.post(
+        "/api/agents",
+        json={
+            "name": "BothOrcidBot",
+            "human_operator": "Test User",
+            "orcid_unverified": "0000-0002-1694-233x",
+            "visibility": "public",
+        },
+        headers=auth_headers,
+    )
+    aicid = create_resp.json()["aicid"]
+
+    user = (await db_session.execute(select(User).where(User.email == "test@example.com"))).scalar_one()
+    user.full_name = "Test User"
+    user.orcid_id = "0000-0002-1825-0097"
+    user.orcid_verified = True
+    await db_session.commit()
+
+    resp = await client.get(f"/agents/{aicid}")
+    assert resp.status_code == 200
+    assert "ORCID Verified" in resp.text
+    assert "ORCID (unverified)" not in resp.text


### PR DESCRIPTION
## Summary
- Addresses #44, but with a different design than the PR #43 proposal: instead of making the existing `operator_orcid` column (reserved for OAuth-verified identity) API-settable, add a new `orcid_unverified` column/field that owners can set through `POST /api/agents` and `PATCH /api/agents/{aicid}`.
- Accepts either a bare ORCID iD or an `orcid.org` URL, validates the ISO 7064 MOD 11-2 checksum, and stores the canonical HTTPS URL; invalid values are rejected with HTTP 422; `null` clears it.
- Public profile shows it as a distinct, muted "ORCID (unverified)" badge — never the green "ORCID Verified" badge, and the verified badge always takes precedence when both are present.
- `operator_orcid` and the OAuth verification flow are untouched, so there's no ambiguity between self-declared and OAuth-verified identity.

## Why not reuse `operator_orcid`?
`operator_orcid` currently isn't wired to anything (the verified badge is derived from `owner.orcid_id` / `owner.orcid_verified` plus a name match, not from this column) and its name doesn't signal "unverified." Introducing a separate `orcid_unverified` field keeps the self-declared value clearly labeled at the schema level, so API clients and template authors can't accidentally treat it as verified.

## Testing
- `pytest` — 49 passed
- Added coverage for: create/update persistence, canonicalization, X checksums, invalid checksum rejection (422), clearing via `null`, public profile showing the unverified badge, and the verified badge taking precedence over the unverified one when both exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)